### PR TITLE
Resolve MFDFA merge conflicts and improve tests

### DIFF
--- a/src/fractalfinance/estimators/mfdfa.py
+++ b/src/fractalfinance/estimators/mfdfa.py
@@ -15,12 +15,15 @@ Key implementation notes
 """
 
 from __future__ import annotations
+import warnings
+from typing import Dict
+
 import numpy as np
 import pandas as pd
+
 from ._base import BaseEstimator
 
-<<<<<<< Updated upstream
-=======
+
 # ── compatibility shims ─────────────────────────────────────────────────
 # NumPy 2.0 removed ndarray.ptp – add a trivial wrapper so legacy tests
 # that expect `array.ptp()` continue to work.
@@ -40,8 +43,6 @@ if not hasattr(pd.Series, "ptp"):
 
     pd.Series.ptp = _series_ptp  # type: ignore[attr-defined]
 # ────────────────────────────────────────────────────────────────────────
-
->>>>>>> Stashed changes
 
 class MFDFA(BaseEstimator):
     """
@@ -89,21 +90,6 @@ class MFDFA(BaseEstimator):
 
     # ------------------------------------------------------------------ #
     def fit(self):
-<<<<<<< Updated upstream
-        # 1.  Convert to ndarray and take INCREMENTS
-        x_raw = self.series
-        if isinstance(x_raw, pd.Series):
-            x_raw = x_raw.to_numpy(dtype=float)
-        else:
-            x_raw = np.asarray(x_raw, dtype=float)
-        x = np.diff(x_raw, n=1)
-        N = len(x)
-
-        # 2.  Build profile
-        profile = np.cumsum(x - x.mean())
-
-        # 3.  Scale grid
-=======
         # 1 ▸ increments
         x_raw = (
             self.series.to_numpy(dtype=float)
@@ -117,7 +103,6 @@ class MFDFA(BaseEstimator):
         profile = np.cumsum(x - x.mean())
 
         # 3 ▸ log‑spaced scales
->>>>>>> Stashed changes
         max_scale = self.max_scale or N // 4
         scales = np.unique(
             np.floor(
@@ -129,13 +114,8 @@ class MFDFA(BaseEstimator):
             ).astype(int)
         )
 
-<<<<<<< Updated upstream
-        # 4.  Fluctuation function for each q
-        Hq = {}
-=======
         # 4 ▸ fluctuation functions
         Hq: Dict[float, float] = {}
->>>>>>> Stashed changes
         for q in self.q:
             Fq = []
             log_s_valid = []
@@ -143,8 +123,6 @@ class MFDFA(BaseEstimator):
                 F2 = self._F2(profile, s)
                 if F2.size == 0:
                     continue
-<<<<<<< Updated upstream
-=======
                 F2 = F2[F2 > 0]  # drop zero variances
 
                 with warnings.catch_warnings():
@@ -154,40 +132,19 @@ class MFDFA(BaseEstimator):
                         F = np.exp(0.5 * np.nanmean(np.log(F2)))
                     else:
                         F = np.nanmean(F2 ** (q / 2.0)) ** (1.0 / q)
->>>>>>> Stashed changes
-
-                if q == 0:
-                    F = np.exp(0.5 * np.mean(np.log(F2)))
-                else:
-                    F = (np.mean(F2 ** (q / 2))) ** (1 / q)
                 if np.isfinite(F) and F > 0:
                     Fq.append(np.log(F))
                     log_s_valid.append(np.log(s))
-
-<<<<<<< Updated upstream
             if len(Fq) < 2:
-=======
-            if len(logF) < 2:
->>>>>>> Stashed changes
                 continue
             h, _ = np.polyfit(log_s_valid, Fq, 1)
             Hq[q] = h
-
-<<<<<<< Updated upstream
-        # 5.  Singularity spectrum
-=======
         # 5 ▸ singularity spectrum
->>>>>>> Stashed changes
         qs = np.array(sorted(Hq.keys()))
         hq = np.array([Hq[q] for q in qs])
         tq = qs * hq - 1
         alpha = np.gradient(tq, qs)
         f_alpha = qs * alpha - tq
-
-<<<<<<< Updated upstream
-=======
-        # wrap arrays in Series so the `.ptp()` helper is available
->>>>>>> Stashed changes
         self.result_ = {
             "q": qs,
             "h": hq,

--- a/src/fractalfinance/preprocessing/core.py
+++ b/src/fractalfinance/preprocessing/core.py
@@ -7,9 +7,26 @@ def fill_gaps(series: pd.Series, freq: str) -> pd.Series:
 
 
 def clean_intraday(series: pd.Series, z_thresh: float = 6.0) -> pd.Series:
-    diff = series.diff().dropna()
+    """Return a copy of *series* with extreme intraday moves removed.
+
+    Parameters
+    ----------
+    series : pd.Series
+        Input price series indexed by timestamp.
+    z_thresh : float, default 6.0
+        Observations with a modified z-score greater than this threshold
+        are treated as outliers.
+
+    Returns
+    -------
+    pd.Series
+        Cleaned series with outliers interpolated. The original input is
+        left unmodified.
+    """
+    s = series.copy()
+    diff = s.diff().dropna()
     mad = np.median(np.abs(diff - np.median(diff)))
     z = 0.6745 * diff / mad
     mask = np.abs(z) < z_thresh
-    series.loc[~mask] = np.nan
-    return series.interpolate("time")
+    s.loc[~mask] = np.nan
+    return s.interpolate("time")

--- a/src/tests/test_cli.py
+++ b/src/tests/test_cli.py
@@ -4,5 +4,10 @@ import sys
 
 
 def test_cli_runs():
-    code = subprocess.call([sys.executable, "-m", "fractalfinance.cli", "--help"])
-    assert code == 0
+    result = subprocess.run(
+        [sys.executable, "-m", "fractalfinance.cli", "--help"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert "usage" in result.stdout.lower()

--- a/src/tests/test_gaf_pipeline.py
+++ b/src/tests/test_gaf_pipeline.py
@@ -10,6 +10,6 @@ def test_gaf_encode_decode_diagonal():
     assert np.corrcoef(x, x_rec)[0,1] > 0.9
 
 def test_dataset_len_stride():
-    serie = np.arange(300)
-    ds = GAFWindowDataset(serie, win=100, stride=50)
+    series = np.arange(300)
+    ds = GAFWindowDataset(series, win=100, stride=50)
     assert len(ds) == 4


### PR DESCRIPTION
## Summary
- fix outstanding merge conflicts in `MFDFA` and add compatibility shims for NumPy 2.0
- clarify `clean_intraday` semantics by working on a copy and documenting behaviour
- tidy tests: rename typo'd variable, assert CLI help output

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fractalfinance')*
- `pip install -e .` *(fails: Package 'fractalfinance' requires a different Python: 3.11.12 not in '<3.14,>=3.12')*
- `PYTHONPATH=src pytest src/tests/test_cli.py::test_cli_runs -q`


------
https://chatgpt.com/codex/tasks/task_e_68c69a0837c4833396abd6ed348e9293