### PR TITLE
Add fractal risk measures and tests

### DIFF
--- a/src/fractalfinance/risk/__init__.py
+++ b/src/fractalfinance/risk/__init__.py
@@ -1,11 +1,30 @@
 from .backtest import acerbi_szekely, christoffersen, kupiec
-from .var import es_evt, es_gaussian, var_evt, var_gaussian
+from .var import (
+    es_evt,
+    es_evt_fractal,
+    es_gaussian,
+    es_stable,
+    multifractal_var,
+    regime_dependent_risk,
+    spectral_risk_measure,
+    var_evt,
+    var_evt_fractal,
+    var_gaussian,
+    var_stable,
+)
 
 __all__ = [
     "var_gaussian",
+    "var_stable",
     "es_gaussian",
+    "es_stable",
     "var_evt",
+    "var_evt_fractal",
     "es_evt",
+    "es_evt_fractal",
+    "spectral_risk_measure",
+    "multifractal_var",
+    "regime_dependent_risk",
     "kupiec",
     "christoffersen",
     "acerbi_szekely",

--- a/src/fractalfinance/risk/var.py
+++ b/src/fractalfinance/risk/var.py
@@ -1,15 +1,27 @@
-"""
-Value‑at‑Risk (VaR) and Expected Shortfall (ES)
-===============================================
-* var_gaussian / es_gaussian – parametric normal formulas
-* var_evt      / es_evt      – POT‑EVT tail using maximum‑likelihood GPD
+"""Fractal and classical risk measures.
+
+The module now complements the traditional Gaussian and EVT estimators
+with heavy-tailed and multifractal counterparts inspired by the thesis
+chapter on fractal risk management:
+
+* :func:`var_gaussian` / :func:`es_gaussian` – parametric normal formulas
+* :func:`var_evt`      / :func:`es_evt`      – POT-EVT tail via maximum-
+  likelihood GPD
+* :func:`var_stable`   / :func:`es_stable`   – α-stable (fractal) risk measures
+* :func:`spectral_risk_measure` – spectral risk measure estimator
+* :func:`multifractal_var` – VaR with multifractal scaling
+* :func:`var_evt_fractal` / :func:`es_evt_fractal` – EVT with dynamic GPD
+  shape linked to multifractal width
+* :func:`regime_dependent_risk` – regime-sensitive risk proxy
 """
 
 from __future__ import annotations
 
+from collections.abc import Callable
+
 import numpy as np
 from numpy.typing import ArrayLike
-from scipy.stats import genpareto, norm
+from scipy.stats import genpareto, levy_stable, norm
 
 
 # ------------------------------------------------------------------ #
@@ -22,6 +34,111 @@ def es_gaussian(sigma: float | np.ndarray, p: float = 0.99) -> np.ndarray:
     """Gaussian Expected Shortfall."""
     z = norm.ppf(p)
     return (sigma / (1.0 - p)) * norm.pdf(z)
+
+
+# ------------------------------------------------------------------ #
+def var_stable(
+    mu: float | np.ndarray,
+    gamma: float | np.ndarray,
+    alpha: float,
+    beta: float = 0.0,
+    p: float = 0.99,
+) -> np.ndarray:
+    """Stable (α-stable) Value-at-Risk."""
+
+    if not 0.0 < alpha <= 2.0:
+        raise ValueError("alpha must be in (0, 2]")
+    if not -1.0 <= beta <= 1.0:
+        raise ValueError("beta must be within [-1, 1]")
+    if not 0.0 < p < 1.0:
+        raise ValueError("p must lie in (0, 1)")
+
+    q = levy_stable.ppf(p, alpha, beta)
+    return np.asarray(mu, dtype=float) + np.asarray(gamma, dtype=float) * q
+
+
+def es_stable(
+    mu: float | np.ndarray,
+    gamma: float | np.ndarray,
+    alpha: float,
+    beta: float = 0.0,
+    p: float = 0.99,
+) -> np.ndarray:
+    """Stable (α-stable) Expected Shortfall."""
+
+    if alpha <= 1.0:
+        return np.full_like(np.asarray(mu, dtype=float), np.inf, dtype=float)
+    if not 0.0 < p < 1.0:
+        raise ValueError("p must lie in (0, 1)")
+
+    q = levy_stable.ppf(p, alpha, beta)
+    cond_mean = levy_stable.expect(
+        lambda x: x,
+        args=(alpha, beta),
+        lb=float(q),
+        conditional=True,
+    )
+    return np.asarray(mu, dtype=float) + np.asarray(gamma, dtype=float) * cond_mean
+
+
+def spectral_risk_measure(
+    losses: ArrayLike,
+    phi: Callable[[np.ndarray], ArrayLike] | ArrayLike,
+) -> float:
+    """Spectral risk measure :math:`ρ_φ(X)` using a discrete approximation."""
+
+    loss = np.sort(np.asarray(losses, dtype=float))
+    if loss.size == 0:
+        raise ValueError("losses must contain at least one observation")
+
+    u = (np.arange(1, loss.size + 1) - 0.5) / loss.size
+    weights = phi(u) if callable(phi) else phi
+    weights = np.asarray(weights, dtype=float)
+
+    if weights.shape != loss.shape:
+        raise ValueError("phi must match the length of losses")
+    if np.any(weights < 0.0):
+        raise ValueError("phi must be non-negative")
+
+    mean_weight = weights.mean()
+    if mean_weight <= 0.0:
+        raise ValueError("phi must integrate to a positive value")
+
+    normalized = weights / mean_weight  # ensures discrete integral equals one
+    return float(np.mean(normalized * loss))
+
+
+def _default_multifractal_quantile(alpha: float, delta_alpha: float) -> float:
+    base = norm.ppf(alpha)
+    scale = np.exp(0.5 * delta_alpha)
+    return float(base * scale)
+
+
+def multifractal_var(
+    sigma0: float | np.ndarray,
+    delta_t: float,
+    hurst: Callable[[float], float] | float,
+    alpha: float,
+    delta_alpha: float = 0.0,
+    q_alpha: float | None = None,
+    quantile_func: Callable[[float, float], float] | None = None,
+) -> np.ndarray:
+    """Multifractal VaR :math:`σ_0 (Δt)^{h(q_α)} F^{-1}`."""
+
+    if delta_t <= 0.0:
+        raise ValueError("delta_t must be positive")
+    if not 0.0 < alpha < 1.0:
+        raise ValueError("alpha must lie in (0, 1)")
+
+    q = alpha if q_alpha is None else q_alpha
+    h_val = hurst(q) if callable(hurst) else float(hurst)
+    quantile = (
+        _default_multifractal_quantile(alpha, delta_alpha)
+        if quantile_func is None
+        else float(quantile_func(alpha, delta_alpha))
+    )
+    sigma0_arr = np.asarray(sigma0, dtype=float)
+    return sigma0_arr * (delta_t**h_val) * quantile
 
 
 # ------------------------------------------------------------------ #
@@ -101,3 +218,110 @@ def es_evt(
     if k >= 1:
         return np.inf  # ES diverges
     return (var + (beta - k * u)) / (1.0 - k)
+
+
+def var_evt_fractal(
+    x: ArrayLike,
+    p: float = 0.99,
+    threshold_q: float = 0.95,
+    delta_alpha: float | None = None,
+    xi0: float | None = None,
+    beta_coeff: float | None = None,
+    diagnostics: bool = False,
+):
+    """EVT VaR with optional fractal adjustment of the shape parameter."""
+
+    x = np.asarray(x, dtype=float).ravel()
+    u = np.quantile(x, threshold_q)
+    exc = x[x > u] - u
+
+    if exc.size < 50:
+        u = np.quantile(x, 0.90)
+        exc = x[x > u] - u
+
+    k_mle, beta = _fit_gpd_mle(exc)
+    ad = _anderson_darling_gpd(exc, k_mle, beta)
+
+    if None not in (delta_alpha, xi0, beta_coeff):
+        k = xi0 + beta_coeff * float(delta_alpha)
+    else:
+        k = k_mle
+
+    n, n_exc = x.size, exc.size
+    tail_prob = (1.0 - p) / (n_exc / n)
+
+    if k != 0:
+        var = u + (beta / k) * (tail_prob ** (-k) - 1.0)
+    else:
+        var = u - beta * np.log(tail_prob)
+
+    if diagnostics:
+        i = (np.arange(1, exc.size + 1) - 0.5) / exc.size
+        theo = genpareto.ppf(i, c=k, scale=beta)
+        return float(var), float(ad), (np.sort(exc), theo)
+
+    return float(var)
+
+
+def es_evt_fractal(
+    x: ArrayLike,
+    p: float = 0.99,
+    threshold_q: float = 0.95,
+    delta_alpha: float | None = None,
+    xi0: float | None = None,
+    beta_coeff: float | None = None,
+) -> float:
+    """Fractal Expected Shortfall corresponding to :func:`var_evt_fractal`."""
+
+    x = np.asarray(x, dtype=float).ravel()
+    u = np.quantile(x, threshold_q)
+    exc = x[x > u] - u
+
+    if exc.size < 50:
+        u = np.quantile(x, 0.90)
+        exc = x[x > u] - u
+
+    k_mle, beta = _fit_gpd_mle(exc)
+    if None not in (delta_alpha, xi0, beta_coeff):
+        k = xi0 + beta_coeff * float(delta_alpha)
+    else:
+        k = k_mle
+
+    var = var_evt_fractal(
+        x,
+        p=p,
+        threshold_q=threshold_q,
+        delta_alpha=delta_alpha,
+        xi0=xi0,
+        beta_coeff=beta_coeff,
+    )
+
+    if k >= 1:
+        return float("inf")
+
+    return float((var + (beta - k * u)) / (1.0 - k))
+
+
+def regime_dependent_risk(
+    delta_alpha: ArrayLike,
+    hurst: ArrayLike,
+    sigma: ArrayLike,
+    delta_t: float = 1.0,
+    weights: tuple[float, float, float] = (1.0, 1.0, 1.0),
+) -> np.ndarray:
+    """Simple proxy :math:`f(Δα_t, H_t, σ_t)` for regime-dependent risk."""
+
+    if delta_t <= 0.0:
+        raise ValueError("delta_t must be positive")
+    if len(weights) != 3:
+        raise ValueError("weights must contain three elements")
+
+    w_delta, w_hurst, w_sigma = (float(w) for w in weights)
+    delta_alpha = np.asarray(delta_alpha, dtype=float)
+    hurst = np.asarray(hurst, dtype=float)
+    sigma = np.asarray(sigma, dtype=float)
+
+    scaling = 1.0 + w_delta * delta_alpha
+    hurst_scale = delta_t ** (w_hurst * hurst)
+    sigma_term = w_sigma * sigma
+    return sigma_term * scaling * hurst_scale

--- a/src/tests/test_risk.py
+++ b/src/tests/test_risk.py
@@ -1,7 +1,22 @@
 import numpy as np
 
-from fractalfinance.risk import (acerbi_szekely, christoffersen, es_evt,
-                                 es_gaussian, kupiec, var_evt, var_gaussian)
+from fractalfinance.risk import (
+    acerbi_szekely,
+    christoffersen,
+    es_evt,
+    es_evt_fractal,
+    es_gaussian,
+    es_stable,
+    kupiec,
+    multifractal_var,
+    regime_dependent_risk,
+    spectral_risk_measure,
+    var_evt,
+    var_evt_fractal,
+    var_gaussian,
+    var_stable,
+)
+from fractalfinance.risk.var import _fit_gpd_mle
 
 
 def test_parametric_var_monotone():
@@ -27,3 +42,64 @@ def test_acerbi_zscore_centered():
     es = var * 1.2
     z = acerbi_szekely(loss, var, es)
     assert abs(z) < 3  # ≈ N(0,1)
+
+
+def test_stable_var_heavier_tail():
+    sigma = 0.02
+    normal = var_gaussian(sigma, 0.99)
+    stable = var_stable(0.0, sigma, alpha=1.7, beta=0.0, p=0.99)
+    assert stable > normal
+
+
+def test_stable_es_infinite_when_alpha_leq_one():
+    es = es_stable(0.0, 1.0, alpha=0.8, beta=0.0, p=0.99)
+    assert np.isinf(es)
+
+
+def test_spectral_risk_tail_averse():
+    losses = np.linspace(0.5, 5.0, 64)
+    flat = spectral_risk_measure(losses, lambda u: np.ones_like(u))
+    tail = spectral_risk_measure(losses, lambda u: u**4)
+    assert tail > flat
+
+
+def test_multifractal_var_monotone_in_delta_alpha():
+    base = multifractal_var(0.02, delta_t=1.0, hurst=0.5, alpha=0.99, delta_alpha=0.0)
+    stressed = multifractal_var(
+        0.02, delta_t=1.0, hurst=0.5, alpha=0.99, delta_alpha=0.6
+    )
+    assert stressed > base
+
+
+def test_var_evt_fractal_matches_evt_without_adjustment():
+    rng = np.random.default_rng(0)
+    losses = np.abs(rng.standard_t(df=4, size=5000))
+    base = var_evt(losses, 0.99)
+    fractal = var_evt_fractal(losses, 0.99)
+    assert np.isclose(base, fractal, rtol=1e-6)
+
+
+def test_var_evt_fractal_increases_with_positive_delta_alpha():
+    rng = np.random.default_rng(1)
+    losses = np.abs(rng.standard_t(df=4, size=6000))
+    u = np.quantile(losses, 0.95)
+    exc = losses[losses > u] - u
+    xi0, _ = _fit_gpd_mle(exc)
+    base = var_evt(losses, 0.99)
+    adj = var_evt_fractal(losses, 0.99, delta_alpha=0.5, xi0=xi0, beta_coeff=0.4)
+    assert adj > base
+
+
+def test_es_evt_fractal_infinite_when_shape_at_least_one():
+    rng = np.random.default_rng(2)
+    losses = rng.lognormal(mean=0.0, sigma=0.6, size=4000)
+    es = es_evt_fractal(losses, 0.99, delta_alpha=0.0, xi0=1.1, beta_coeff=0.0)
+    assert np.isinf(es)
+
+
+def test_regime_dependent_risk_increasing_components():
+    delta_alpha = np.array([0.0, 0.3])
+    hurst = np.array([0.4, 0.6])
+    sigma = np.array([0.02, 0.02])
+    risk = regime_dependent_risk(delta_alpha, hurst, sigma, delta_t=1.0)
+    assert risk[1] > risk[0]


### PR DESCRIPTION
## Summary
- extend the risk module with fractal-aware VaR/ES estimators, spectral risk measures, multifractal scaling, and regime-sensitive helpers
- expose the new functionality through the public risk API
- add comprehensive unit tests covering the new fractal risk metrics

## Testing
- PYTHONPATH=src pytest src/tests/test_risk.py

------
https://chatgpt.com/codex/tasks/task_e_68c8d188321c833397a598638a2a9a30