### PR TITLE
Align GAF implementation with theoretical definitions

### DIFF
--- a/src/fractalfinance/gaf/gaf.py
+++ b/src/fractalfinance/gaf/gaf.py
@@ -1,32 +1,55 @@
 import numpy as np
 from PIL import Image
 
-def _to_unit(x: np.ndarray, detrend: bool = False) -> tuple[np.ndarray, float, float]:
-    """Normalise ``x`` to ``[-1, 1]`` with optional linear detrending."""
+
+def _to_unit(
+    x: np.ndarray,
+    detrend: bool = False,
+    scale: str = "symmetric",
+) -> tuple[np.ndarray, float, float]:
+    """Normalise ``x`` according to ``scale`` with optional linear detrending."""
+
     if detrend:
         t = np.arange(len(x))
         a, b = np.polyfit(t, x, 1)
         x = x - (a * t + b)
+
     x_min, x_max = float(x.min()), float(x.max())
-    unit = 2 * (x - x_min) / (x_max - x_min) - 1
-    return unit, x_min, x_max
+    span = x_max - x_min
+
+    if np.isclose(span, 0.0):
+        unit = np.zeros_like(x, dtype=float)
+    elif scale == "symmetric":
+        unit = 2 * (x - x_min) / span - 1
+    elif scale in {"zero-one", "[0, 1]"}:
+        unit = (x - x_min) / span
+    else:
+        raise ValueError("scale must be 'symmetric' or 'zero-one'")
+
+    return unit.astype(float, copy=False), x_min, x_max
 
 
-def _polar(x: np.ndarray):
-    phi = np.arccos(x)
-    rho = np.linspace(0, 1, len(x))
+def _polar(x: np.ndarray, representation: str) -> tuple[np.ndarray, np.ndarray]:
+    x = np.clip(x, -1.0, 1.0)
+    if representation == "gasf":
+        phi = np.arccos(x)
+    elif representation == "gadf":
+        phi = np.arcsin(x)
+    else:
+        raise ValueError("representation must be 'gasf' or 'gadf'")
+    rho = np.linspace(0, 1, len(x), dtype=float)
     return rho, phi
 
 
-def GASF(x: np.ndarray, detrend: bool = False) -> np.ndarray:
-    u, _, _ = _to_unit(x, detrend=detrend)
-    rho, phi = _polar(u)
+def GASF(x: np.ndarray, detrend: bool = False, scale: str = "symmetric") -> np.ndarray:
+    u, _, _ = _to_unit(x, detrend=detrend, scale=scale)
+    _, phi = _polar(u, "gasf")
     return np.cos(phi[:, None] + phi[None, :])
 
 
-def GADF(x: np.ndarray, detrend: bool = False) -> np.ndarray:
-    u, _, _ = _to_unit(x, detrend=detrend)
-    rho, phi = _polar(u)
+def GADF(x: np.ndarray, detrend: bool = False, scale: str = "symmetric") -> np.ndarray:
+    u, _, _ = _to_unit(x, detrend=detrend, scale=scale)
+    _, phi = _polar(u, "gadf")
     return np.sin(phi[None, :] - phi[:, None])
 
 
@@ -36,6 +59,7 @@ def gaf_encode(
     resize: int | None = 128,
     return_params: bool = False,
     detrend: bool = False,
+    scale: str = "symmetric",
 ) -> np.ndarray | tuple[np.ndarray, float, float, np.ndarray]:
     """Encode ``x`` into a Gramian Angular Field.
 
@@ -44,13 +68,21 @@ def gaf_encode(
     normalised series so that a perfect reconstruction is possible with
     :func:`gaf_decode`.
     """
-    u, x_min, x_max = _to_unit(x, detrend=detrend)
-    img = GASF(u, detrend=False) if kind.lower() == "gasf" else GADF(u, detrend=False)
+    kind = kind.lower()
+    u, x_min, x_max = _to_unit(x, detrend=detrend, scale=scale)
+    _, phi = _polar(u, kind)
+    if kind == "gasf":
+        img = np.cos(phi[:, None] + phi[None, :])
+    elif kind == "gadf":
+        img = np.sin(phi[None, :] - phi[:, None])
+    else:
+        raise ValueError("kind must be 'gasf' or 'gadf'")
     if resize:
         img = np.array(Image.fromarray(img).resize((resize, resize), Image.BILINEAR))
     img = img.astype(np.float32)
     if return_params:
-        return img, x_min, x_max, np.sign(u)
+        sign = np.where(u >= 0, 1.0, -1.0)
+        return img, x_min, x_max, sign
     return img
 
 
@@ -72,6 +104,7 @@ def gaf_decode(
     x_min: float,
     x_max: float,
     sign: np.ndarray,
+    scale: str = "symmetric",
 ) -> np.ndarray:
     """Reconstruct the original series from a GASF diagonal.
 
@@ -84,5 +117,11 @@ def gaf_decode(
     sign:
         Sign of the normalised series returned by :func:`gaf_encode`.
     """
-    x_unit = np.sqrt((diagonal_val + 1) / 2) * sign
-    return (x_unit + 1) / 2 * (x_max - x_min) + x_min
+    diagonal_val = np.clip(diagonal_val, -1.0, 1.0)
+    x_unit = np.sqrt((diagonal_val + 1) / 2)
+    if scale == "symmetric":
+        x_unit = x_unit * sign
+        return (x_unit + 1) / 2 * (x_max - x_min) + x_min
+    if scale in {"zero-one", "[0, 1]"}:
+        return x_unit * (x_max - x_min) + x_min
+    raise ValueError("scale must be 'symmetric' or 'zero-one'")

--- a/src/tests/test_gaf.py
+++ b/src/tests/test_gaf.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from fractalfinance.gaf import GASF, gaf_encode
+from fractalfinance.gaf import GADF, GASF, gaf_decode, gaf_encode
 
 
 def test_gaf_dimensions():
@@ -13,3 +13,30 @@ def test_gasf_symmetry():
     x = np.random.randn(100)
     img = GASF(x)
     assert np.allclose(img, img.T, atol=1e-6)
+
+
+def test_gadf_definition_matches_arcsin():
+    x = np.linspace(-2.0, 3.0, 10)
+    gadf = GADF(x)
+
+    x_min, x_max = x.min(), x.max()
+    u = 2 * (x - x_min) / (x_max - x_min) - 1
+    phi = np.arcsin(np.clip(u, -1.0, 1.0))
+    expected = np.sin(phi[None, :] - phi[:, None])
+
+    assert np.allclose(gadf, expected, atol=1e-6)
+
+
+def test_gaf_decode_zero_one_scale():
+    rng = np.random.default_rng(0)
+    x = rng.uniform(10.0, 25.0, size=32)
+    img, x_min, x_max, sign = gaf_encode(
+        x,
+        kind="gasf",
+        resize=None,
+        return_params=True,
+        scale="zero-one",
+    )
+
+    reconstructed = gaf_decode(np.diag(img), x_min, x_max, sign, scale="zero-one")
+    assert np.allclose(reconstructed, x, atol=1e-6)


### PR DESCRIPTION
## Summary
- align the Gramian Angular Field helpers with the documented GASF/GADF definitions by selecting the appropriate angular mapping and adding explicit scaling modes
- update encoding and decoding utilities to expose the scaling option and improve reconstruction stability when normalising degenerate series
- extend the unit test suite to cover the GADF arcsin construction and verify decoding when using zero-one scaling

## Testing
- PYTHONPATH=src poetry run pytest src/tests/test_gaf.py


------
https://chatgpt.com/codex/tasks/task_e_68c8d32ea1ac8333ab5550126c5456ce