### PR TITLE
Ensure generated plots save to analysis_outputs

### DIFF
--- a/src/examples/plotting.py
+++ b/src/examples/plotting.py
@@ -1,80 +1,61 @@
-import matplotlib
-matplotlib.use('Agg')
-import matplotlib.pyplot as plt
-import numpy as np
+"""Thin wrappers around :mod:`fractalfinance.plotting` for example scripts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Union
+
 import typer
 
-from fractalfinance.gaf.gaf import gaf_encode
-from fractalfinance.models.fbm import fbm
-from fractalfinance.models.mmar import simulate
-
-
-def plot_fbm(path: str = "fbm.png", H: float = 0.7, n: int = 1024) -> str:
-    """Generate and save a sample Fractional Brownian Motion path."""
-    series = fbm(H=H, n=n, seed=0)
-    plt.figure(figsize=(8, 4))
-    plt.plot(series, lw=1)
-    plt.title("Fractional Brownian Motion")
-    plt.tight_layout()
-    plt.savefig(path)
-    plt.close()
-    return path
-
-
-def plot_gaf(path: str = "gaf.png", H: float = 0.7, n: int = 256) -> str:
-    """Generate a series and visualise its GASF and GADF."""
-    series = fbm(H=H, n=n, seed=0)
-    gasf = gaf_encode(series, kind="gasf", resize=n)
-    gadf = gaf_encode(series, kind="gadf", resize=n)
-    fig, axes = plt.subplots(1, 3, figsize=(12, 4))
-    axes[0].plot(series, lw=1)
-    axes[0].set_title("Series")
-    axes[1].imshow(gasf, cmap="jet")
-    axes[1].set_title("GASF")
-    axes[1].axis("off")
-    axes[2].imshow(gadf, cmap="jet")
-    axes[2].set_title("GADF")
-    axes[2].axis("off")
-    fig.tight_layout()
-    fig.savefig(path)
-    plt.close(fig)
-    return path
-
-
-def plot_mmar(path: str = "mmar.png", H: float = 0.7, n: int = 1024) -> str:
-    """Simulate a Multifractal Multivariate AR path and its multipliers."""
-    theta, X, r = simulate(n=n, H=H, seed=0)
-    fig, axes = plt.subplots(3, 1, figsize=(8, 6), sharex=True)
-    axes[0].plot(theta, lw=1)
-    axes[0].set_title("Multipliers")
-    axes[1].plot(r, lw=1)
-    axes[1].set_title("Returns")
-    axes[2].plot(X, lw=1)
-    axes[2].set_title("MMAR path")
-    fig.tight_layout()
-    fig.savefig(path)
-    plt.close(fig)
-    return path
-
+from fractalfinance.plotting import DEFAULT_OUTPUT_DIR, plot_fbm as _plot_fbm
+from fractalfinance.plotting import plot_gaf as _plot_gaf
+from fractalfinance.plotting import plot_mmar as _plot_mmar
 
 app = typer.Typer(help="Generate example plots for fractal processes.")
 
 
+def plot_fbm(
+    path: Union[str, Path] = DEFAULT_OUTPUT_DIR / "fbm.png", H: float = 0.7, n: int = 1024
+) -> str:
+    """Create an FBM plot and save it to *path*."""
+
+    return _plot_fbm(path=path, H=H, n=n)
+
+
+def plot_gaf(
+    path: Union[str, Path] = DEFAULT_OUTPUT_DIR / "gaf.png", H: float = 0.7, n: int = 256
+) -> str:
+    """Create GASF/GADF plots and save them to *path*."""
+
+    return _plot_gaf(path=path, H=H, n=n)
+
+
+def plot_mmar(
+    path: Union[str, Path] = DEFAULT_OUTPUT_DIR / "mmar.png", H: float = 0.7, n: int = 1024
+) -> str:
+    """Create an MMAR plot and save it to *path*."""
+
+    return _plot_mmar(path=path, H=H, n=n)
+
+
 @app.command()
-def fbm_cmd(path: str = "fbm.png"):
+def fbm_cmd(path: Path = DEFAULT_OUTPUT_DIR / "fbm.png") -> None:
     """Create an FBM plot and save it to PATH."""
+
     typer.echo(plot_fbm(path))
 
 
 @app.command()
-def gaf_cmd(path: str = "gaf.png"):
+def gaf_cmd(path: Path = DEFAULT_OUTPUT_DIR / "gaf.png") -> None:
     """Create GASF/GADF plots and save them to PATH."""
+
     typer.echo(plot_gaf(path))
 
 
 @app.command()
-def mmar_cmd(path: str = "mmar.png"):
+def mmar_cmd(path: Path = DEFAULT_OUTPUT_DIR / "mmar.png") -> None:
     """Create an MMAR plot and save it to PATH."""
+
     typer.echo(plot_mmar(path))
 
 

--- a/src/fractalfinance/cli.py
+++ b/src/fractalfinance/cli.py
@@ -20,6 +20,7 @@ from typing import List
 import typer
 
 from . import plotting
+from .plotting import DEFAULT_OUTPUT_DIR
 
 # ──────────────────────────────────────────────────────────────────────────────
 # create Typer app; disable Rich markup so help text prints safely in the
@@ -88,19 +89,19 @@ plot_app = typer.Typer(help="Generate plots for fractal processes.")
 
 
 @plot_app.command("fbm")
-def fbm_cmd(path: str = "fbm.png") -> None:
+def fbm_cmd(path: Path = DEFAULT_OUTPUT_DIR / "fbm.png") -> None:
     """Create an FBM plot and save it to PATH."""
     typer.echo(plotting.plot_fbm(path))
 
 
 @plot_app.command("gaf")
-def gaf_cmd(path: str = "gaf.png") -> None:
+def gaf_cmd(path: Path = DEFAULT_OUTPUT_DIR / "gaf.png") -> None:
     """Create GASF/GADF plots and save them to PATH."""
     typer.echo(plotting.plot_gaf(path))
 
 
 @plot_app.command("mmar")
-def mmar_cmd(path: str = "mmar.png") -> None:
+def mmar_cmd(path: Path = DEFAULT_OUTPUT_DIR / "mmar.png") -> None:
     """Create an MMAR plot and save it to PATH."""
     typer.echo(plotting.plot_mmar(path))
 

--- a/src/fractalfinance/plotting.py
+++ b/src/fractalfinance/plotting.py
@@ -1,29 +1,68 @@
+"""Utility helpers for generating fractal-finance plots.
+
+The plotting functions default to saving output under an ``analysis_outputs``
+folder at the project root. If the caller specifies a custom path the required
+parent directories are created automatically, so plots from scripted analyses
+end up in a consistent location.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Union
+
 import matplotlib
-matplotlib.use('Agg')
+
+matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 
 from fractalfinance.gaf.gaf import gaf_encode
 from fractalfinance.models.fbm import fbm
 from fractalfinance.models.mmar import simulate
 
+__all__ = [
+    "plot_fbm",
+    "plot_gaf",
+    "plot_mmar",
+    "DEFAULT_OUTPUT_DIR",
+]
 
-__all__ = ["plot_fbm", "plot_gaf", "plot_mmar"]
+DEFAULT_OUTPUT_DIR = Path("analysis_outputs")
 
 
-def plot_fbm(path: str = "fbm.png", H: float = 0.7, n: int = 1024) -> str:
+def _prepare_path(path: Union[str, Path]) -> Path:
+    """Create parent directories for *path* and return it as a :class:`Path`."""
+
+    save_path = Path(path).expanduser()
+    if save_path.parent == Path('.'):
+        DEFAULT_OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+        save_path = DEFAULT_OUTPUT_DIR / save_path.name
+    else:
+        save_path.parent.mkdir(parents=True, exist_ok=True)
+    return save_path
+
+
+def plot_fbm(
+    path: Union[str, Path] = DEFAULT_OUTPUT_DIR / "fbm.png", H: float = 0.7, n: int = 1024
+) -> str:
     """Generate and save a sample Fractional Brownian Motion path."""
+
     series = fbm(H=H, n=n, seed=0)
     plt.figure(figsize=(8, 4))
     plt.plot(series, lw=1)
     plt.title("Fractional Brownian Motion")
     plt.tight_layout()
-    plt.savefig(path)
+    save_path = _prepare_path(path)
+    plt.savefig(save_path)
     plt.close()
-    return path
+    return str(save_path)
 
 
-def plot_gaf(path: str = "gaf.png", H: float = 0.7, n: int = 256) -> str:
+def plot_gaf(
+    path: Union[str, Path] = DEFAULT_OUTPUT_DIR / "gaf.png", H: float = 0.7, n: int = 256
+) -> str:
     """Generate a series and visualise its GASF and GADF."""
+
     series = fbm(H=H, n=n, seed=0)
     gasf = gaf_encode(series, kind="gasf", resize=n)
     gadf = gaf_encode(series, kind="gadf", resize=n)
@@ -37,13 +76,17 @@ def plot_gaf(path: str = "gaf.png", H: float = 0.7, n: int = 256) -> str:
     axes[2].set_title("GADF")
     axes[2].axis("off")
     fig.tight_layout()
-    fig.savefig(path)
+    save_path = _prepare_path(path)
+    fig.savefig(save_path)
     plt.close(fig)
-    return path
+    return str(save_path)
 
 
-def plot_mmar(path: str = "mmar.png", H: float = 0.7, n: int = 1024) -> str:
+def plot_mmar(
+    path: Union[str, Path] = DEFAULT_OUTPUT_DIR / "mmar.png", H: float = 0.7, n: int = 1024
+) -> str:
     """Simulate a Multifractal Multivariate AR path and its multipliers."""
+
     theta, X, r = simulate(n=n, H=H, seed=0)
     fig, axes = plt.subplots(3, 1, figsize=(8, 6), sharex=True)
     axes[0].plot(theta, lw=1)
@@ -53,6 +96,7 @@ def plot_mmar(path: str = "mmar.png", H: float = 0.7, n: int = 1024) -> str:
     axes[2].plot(X, lw=1)
     axes[2].set_title("MMAR path")
     fig.tight_layout()
-    fig.savefig(path)
+    save_path = _prepare_path(path)
+    fig.savefig(save_path)
     plt.close(fig)
-    return path
+    return str(save_path)


### PR DESCRIPTION
## Summary
- add a shared DEFAULT_OUTPUT_DIR for plotting utilities that creates the analysis_outputs folder on demand
- update the CLI and example wrappers to default to saving plots into the shared output directory
- add the analysis_outputs/ placeholder so generated figures have a tracked destination

## Testing
- PYTHONPATH=src pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca32d7fd788333a2b5081bd36aa923