### PR TITLE
Add multi-scale GAF and fractal analysis workflow

### DIFF
--- a/src/examples/__init__.py
+++ b/src/examples/__init__.py
@@ -1,5 +1,5 @@
 """Example analysis workflows bundled with the project."""
 
-from . import asset_analysis, sp500_daily_analysis
+from . import asset_analysis, multi_scale_analysis, sp500_daily_analysis
 
-__all__ = ["asset_analysis", "sp500_daily_analysis"]
+__all__ = ["asset_analysis", "multi_scale_analysis", "sp500_daily_analysis"]

--- a/src/examples/asset_analysis.py
+++ b/src/examples/asset_analysis.py
@@ -16,52 +16,22 @@ from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any, Callable, Mapping
 
-import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-from arch import arch_model
 
-from fractalfinance.estimators import DFA, MFDFA, RS, StructureFunction, WTMM
+from fractalfinance.analysis.common import (
+    compute_fractal_metrics,
+    ensure_dir,
+    fit_garch,
+    fit_msm,
+    plot_garch_overlay,
+    plot_mfdfa_spectrum,
+    plot_price_series,
+    plot_returns_histogram,
+    summarise_prices,
+)
 from fractalfinance.io import load_yahoo
-from fractalfinance.models import msm_fit
 from fractalfinance.plotting import DEFAULT_OUTPUT_DIR
-
-
-def _ensure_dir(path: Path) -> Path:
-    path.mkdir(parents=True, exist_ok=True)
-    return path
-
-
-def _save_fig(fig: plt.Figure, out_dir: Path, filename: str) -> str:
-    _ensure_dir(out_dir)
-    target = out_dir / filename
-    fig.savefig(target, dpi=150, bbox_inches="tight")
-    plt.close(fig)
-    return str(target)
-
-
-def _annualise(daily_value: float, days_per_year: float) -> float:
-    return float(daily_value * np.sqrt(days_per_year))
-
-
-def _h_at(mfdfa_res: dict[str, np.ndarray], q: float) -> float | None:
-    qs = mfdfa_res.get("q")
-    hs = mfdfa_res.get("h")
-    if qs is None or hs is None:
-        return None
-    matches = np.where(np.isclose(qs, q))[0]
-    if matches.size == 0:
-        return None
-    return float(hs[matches[0]])
-
-
-def _to_naive(index: pd.Index) -> pd.DatetimeIndex:
-    idx = pd.DatetimeIndex(index)
-    if idx.tz is None:
-        idx = idx.tz_localize("UTC")
-    else:
-        idx = idx.tz_convert("UTC")
-    return idx.tz_localize(None)
 
 
 def _slugify(value: str) -> str:
@@ -117,7 +87,7 @@ def run_asset_analysis(
 
     end = config.end or pd.Timestamp.utcnow().normalize().strftime("%Y-%m-%d")
     output_subdir = config.resolved_output_subdir(base_output_subdir)
-    output_dir = _ensure_dir(DEFAULT_OUTPUT_DIR / output_subdir)
+    output_dir = ensure_dir(DEFAULT_OUTPUT_DIR / output_subdir)
 
     prices = config.loader(
         config.symbol,
@@ -127,122 +97,42 @@ def run_asset_analysis(
     )
     prices = prices.astype(float)
     returns = np.log(prices).diff().dropna()
-
-    obs = int(len(returns))
-    span = f"{prices.index[0].date()} → {prices.index[-1].date()}"
-    price_change = float(prices.iloc[-1] / prices.iloc[0] - 1.0)
-
-    ann_return = float(returns.mean() * config.annualisation_days)
-    ann_vol = float(
-        returns.std(ddof=1) * np.sqrt(config.annualisation_days)
+    stats = summarise_prices(
+        prices,
+        returns,
+        periods_per_year=config.annualisation_days,
     )
-    skew = float(returns.skew())
-    kurt = float(returns.kurt())
-
-    scaled_returns = (returns * 100).rename("ret_pct")
-    am = arch_model(
-        scaled_returns,
-        mean="AR",
-        lags=1,
-        vol="GARCH",
-        p=1,
-        q=1,
-        dist="normal",
-        rescale=False,
-    )
-    garch_res = am.fit(disp="off")
-    cond_vol = garch_res.conditional_volatility / 100.0
-    forecasts = garch_res.forecast(horizon=5, reindex=False)
-    variance_forecast = forecasts.variance.iloc[-1]
-    daily_forecast = [float(np.sqrt(v) / 100.0) for v in variance_forecast]
-
-    garch_summary = {
-        "params": {k: float(v) for k, v in garch_res.params.items()},
-        "last_cond_vol_daily": float(cond_vol.iloc[-1]),
-        "last_cond_vol_annual": _annualise(
-            float(cond_vol.iloc[-1]),
-            config.annualisation_days,
-        ),
-        "forecast_daily_vol": daily_forecast,
-        "forecast_annual_vol": [
-            _annualise(v, config.annualisation_days) for v in daily_forecast
-        ],
-    }
-
-    msm_params = msm_fit(returns.to_numpy(), K=5)
-    msm_summary = {
-        "sigma2": float(msm_params.sigma2),
-        "m_L": float(msm_params.m_L),
-        "m_H": float(msm_params.m_H),
-        "gamma_1": float(msm_params.gamma_1),
-        "b": float(msm_params.b),
-        "K": int(msm_params.K),
-    }
-
-    rs_res = RS(returns).fit().result_
-    dfa_res = DFA(prices, from_levels=True, auto_range=True).fit().result_
-    struct_res = StructureFunction(returns, from_levels=False).fit().result_
-    mfdfa_res = MFDFA(prices, from_levels=True, auto_range=True).fit().result_
-    wtmm_res = WTMM(returns, from_levels=False).fit().result_
-
-    fractal_summary = {
-        "RS_H": float(rs_res["H"]),
-        "DFA_H": float(dfa_res["H"]),
-        "Structure_H": float(struct_res.H),
-        "Structure_lambda": float(struct_res.lambda_),
-        "Structure_delta_alpha": float(struct_res.delta_alpha),
-        "MFDFA_h2": _h_at(mfdfa_res, 2.0),
-        "MFDFA_width": float(
-            np.max(mfdfa_res["alpha"]) - np.min(mfdfa_res["alpha"])
-        ),
-        "WTMM_width": float(
-            np.nanmax(wtmm_res["alpha"]) - np.nanmin(wtmm_res["alpha"])
-        ),
-    }
-
-    idx = _to_naive(prices.index)
-    ret_idx = _to_naive(returns.index)
+    garch = fit_garch(returns, periods_per_year=config.annualisation_days)
+    msm_summary = fit_msm(returns)
+    fractal = compute_fractal_metrics(prices, returns)
 
     price_title = config.price_title or f"{config.label} daily close"
     slug = config.slug
 
-    fig, ax = plt.subplots(figsize=(10, 4))
-    ax.plot(idx, prices.to_numpy(), color="#1f77b4", lw=1.5)
-    ax.set_title(price_title)
-    ax.set_ylabel(config.price_ylabel)
-    ax.grid(True, alpha=0.3)
-    price_path = _save_fig(fig, output_dir, f"{slug}_price.png")
-
-    fig, axes = plt.subplots(2, 1, figsize=(10, 6), sharex=True)
-    axes[0].plot(ret_idx, returns.to_numpy() * 100, color="#ff7f0e", lw=0.8)
-    axes[0].set_ylabel("Log-return (%)")
-    axes[0].set_title("Daily log-returns")
-    axes[0].grid(True, alpha=0.3)
-    axes[1].hist(returns.to_numpy() * 100, bins=50, color="#2ca02c", alpha=0.7)
-    axes[1].set_xlabel("Log-return (%)")
-    axes[1].set_ylabel("Frequency")
-    axes[1].grid(True, alpha=0.3)
-    returns_plot = _save_fig(fig, output_dir, f"{slug}_returns.png")
-
-    fig, ax1 = plt.subplots(figsize=(10, 5))
-    ax1.bar(ret_idx, returns.to_numpy() * 100, color="grey", alpha=0.3, width=1.0)
-    ax1.set_ylabel("Log-return (%)", color="grey")
-    ax1.tick_params(axis="y", labelcolor="grey")
-    ax2 = ax1.twinx()
-    ax2.plot(_to_naive(cond_vol.index), cond_vol * 100, color="#d62728", lw=1.2)
-    ax2.set_ylabel("Cond. volatility (%)", color="#d62728")
-    ax2.tick_params(axis="y", labelcolor="#d62728")
-    ax1.set_title("AR(1)-GARCH(1,1) conditional volatility")
-    ax1.grid(True, alpha=0.3)
-    garch_plot = _save_fig(fig, output_dir, f"{slug}_garch.png")
-
-    fig, ax = plt.subplots(figsize=(8, 6))
-    ax.plot(mfdfa_res["alpha"], mfdfa_res["f_alpha"], marker="o", lw=1.2)
-    ax.set_xlabel("α")
-    ax.set_ylabel("f(α)")
-    ax.set_title("MFDFA singularity spectrum")
-    ax.grid(True, alpha=0.3)
-    mfdfa_plot = _save_fig(fig, output_dir, f"{slug}_mfdfa.png")
+    price_path = plot_price_series(
+        prices,
+        title=price_title,
+        ylabel=config.price_ylabel,
+        out_dir=output_dir,
+        filename=f"{slug}_price.png",
+    )
+    returns_plot = plot_returns_histogram(
+        returns,
+        out_dir=output_dir,
+        filename=f"{slug}_returns.png",
+        title="Log-returns",
+    )
+    garch_plot = plot_garch_overlay(
+        returns,
+        garch.conditional_volatility,
+        out_dir=output_dir,
+        filename=f"{slug}_garch.png",
+    )
+    mfdfa_plot = plot_mfdfa_spectrum(
+        fractal.mfdfa,
+        out_dir=output_dir,
+        filename=f"{slug}_mfdfa.png",
+    )
 
     outputs = {
         "price_path": price_path,
@@ -256,17 +146,11 @@ def run_asset_analysis(
         "label": config.label,
         "symbol": config.symbol,
         "asset_type": config.asset_type,
-        "observations": obs,
-        "span": span,
-        "price_change": price_change,
-        "annualised_return": ann_return,
-        "annualised_volatility": ann_vol,
+        **stats,
         "annualisation_days": config.annualisation_days,
-        "skew": skew,
-        "excess_kurtosis": kurt,
-        "garch": garch_summary,
+        "garch": garch.summary,
         "msm": msm_summary,
-        "fractal": fractal_summary,
+        "fractal": fractal.summary,
         "outputs": outputs,
         "notes": config.notes,
     }

--- a/src/examples/multi_scale_analysis.py
+++ b/src/examples/multi_scale_analysis.py
@@ -1,0 +1,426 @@
+"""Multi-timescale asset analysis combining fractal and GAF diagnostics."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+import numpy as np
+import pandas as pd
+
+from fractalfinance.analysis.common import (
+    compute_fractal_metrics,
+    ensure_dir,
+    fit_garch,
+    fit_msm,
+    infer_periods_per_year,
+    plot_garch_overlay,
+    plot_mfdfa_spectrum,
+    plot_price_series,
+    plot_returns_histogram,
+    summarise_prices,
+)
+from fractalfinance.gaf.dataset import GAFWindowDataset
+from fractalfinance.gaf.gaf import save_gaf_png
+from fractalfinance.io import load_yahoo
+from fractalfinance.plotting import DEFAULT_OUTPUT_DIR
+
+
+def _slugify(value: str) -> str:
+    slug = re.sub(r"[^0-9a-zA-Z]+", "_", value).strip("_")
+    return slug.lower() or "scale"
+
+
+def _median_spacing_seconds(index: pd.Index) -> float | None:
+    idx = pd.DatetimeIndex(index).sort_values()
+    if idx.size < 2:
+        return None
+    diffs = idx.to_series().diff().dropna().dt.total_seconds().to_numpy()
+    if diffs.size == 0:
+        return None
+    return float(np.median(diffs))
+
+
+def _format_duration(seconds: float | None) -> str | None:
+    if seconds is None:
+        return None
+    if seconds <= 0:
+        return None
+    minutes = seconds / 60.0
+    hours = minutes / 60.0
+    days = hours / 24.0
+    if days >= 2.0:
+        return f"{days:.1f} days"
+    if hours >= 2.0:
+        return f"{hours:.1f} hours"
+    if minutes >= 2.0:
+        return f"{minutes:.1f} minutes"
+    return f"{seconds:.0f} seconds"
+
+
+@dataclass(slots=True)
+class GAFScaleConfig:
+    """Parameters used to generate GAF cubes for a specific timescale."""
+
+    window: int
+    stride: int
+    resolutions: Sequence[int]
+    kinds: Sequence[str] = ("gasf", "gadf")
+    detrend: bool = False
+    scale: str = "symmetric"
+    resample: str = "paa"
+    to_uint8: bool = False
+    image_size: int | None = None
+
+
+@dataclass(slots=True)
+class ScaleConfig:
+    """Describe how a given Yahoo! ``interval`` should be analysed."""
+
+    interval: str
+    label: str
+    gaf: GAFScaleConfig
+    min_points: int | None = None
+
+    def resolved_min_points(self) -> int:
+        base = self.min_points if self.min_points is not None else 0
+        return max(base, self.gaf.window + self.gaf.stride)
+
+
+def default_scale_configs() -> list[ScaleConfig]:
+    """Return a conservative set of Yahoo! intervals spanning multiple scales."""
+
+    return [
+        ScaleConfig(
+            interval="1m",
+            label="1-minute",
+            gaf=GAFScaleConfig(
+                window=780,  # roughly two trading days of minute bars
+                stride=60,
+                resolutions=(512, 256),
+                image_size=256,
+            ),
+        ),
+        ScaleConfig(
+            interval="5m",
+            label="5-minute",
+            gaf=GAFScaleConfig(
+                window=720,
+                stride=48,
+                resolutions=(512, 256),
+                image_size=240,
+            ),
+        ),
+        ScaleConfig(
+            interval="15m",
+            label="15-minute",
+            gaf=GAFScaleConfig(
+                window=672,
+                stride=32,
+                resolutions=(384, 256),
+                image_size=224,
+            ),
+        ),
+        ScaleConfig(
+            interval="1h",
+            label="1-hour",
+            gaf=GAFScaleConfig(
+                window=600,
+                stride=24,
+                resolutions=(384, 256),
+                image_size=224,
+            ),
+        ),
+        ScaleConfig(
+            interval="1d",
+            label="Daily",
+            gaf=GAFScaleConfig(
+                window=512,
+                stride=16,
+                resolutions=(512, 256, 128),
+                image_size=256,
+            ),
+        ),
+        ScaleConfig(
+            interval="1wk",
+            label="Weekly",
+            gaf=GAFScaleConfig(
+                window=260,
+                stride=8,
+                resolutions=(256, 128, 64),
+                image_size=192,
+            ),
+        ),
+        ScaleConfig(
+            interval="1mo",
+            label="Monthly",
+            gaf=GAFScaleConfig(
+                window=180,
+                stride=3,
+                resolutions=(180, 120, 60),
+                image_size=160,
+            ),
+        ),
+    ]
+
+
+def _gaf_summary(
+    returns: pd.Series,
+    *,
+    config: GAFScaleConfig,
+    out_dir: Path,
+    slug: str,
+) -> tuple[dict[str, object], list[str]]:
+    series = returns.to_numpy(dtype=float)
+    dataset = GAFWindowDataset(
+        series,
+        win=config.window,
+        stride=config.stride,
+        resize=config.resolutions,
+        kinds=config.kinds,
+        detrend=config.detrend,
+        scale=config.scale,
+        resample=config.resample,
+        to_uint8=config.to_uint8,
+        image_size=config.image_size,
+    )
+    windows = len(dataset)
+    label_distribution: dict[str, int] = {}
+    sample_images: dict[str, str] = {}
+    warnings: list[str] = []
+
+    first_channels = 0
+
+    if windows == 0:
+        warnings.append(
+            "Insufficient samples to form a single GAF window at this scale."
+        )
+    else:
+        labels = []
+        for idx in range(windows):
+            _, label_tensor = dataset[idx]
+            labels.append(int(label_tensor.item()))
+        uniques, counts = np.unique(labels, return_counts=True)
+        label_distribution = {
+            str(int(u)): int(c) for u, c in zip(uniques, counts, strict=False)
+        }
+        cube, _ = dataset[0]
+        cube_np = cube.detach().cpu().numpy()
+        first_channels = int(cube_np.shape[0])
+        image_path = out_dir / f"{slug}_gaf_sample.png"
+        save_gaf_png(cube_np, image_path)
+        sample_images["first_window"] = str(image_path)
+
+    median_spacing = _median_spacing_seconds(returns.index)
+    if median_spacing is None:
+        window_span = None
+    else:
+        window_span = median_spacing * config.window
+
+    summary = {
+        "window": int(config.window),
+        "stride": int(config.stride),
+        "resolutions": [int(r) for r in config.resolutions],
+        "image_size": int(config.image_size or max(config.resolutions)),
+        "kinds": list(config.kinds),
+        "channels": first_channels,
+        "windows": int(windows),
+        "label_distribution": label_distribution,
+        "window_span_seconds": window_span,
+        "window_span_pretty": _format_duration(window_span),
+        "sample_images": sample_images,
+    }
+    return summary, warnings
+
+
+def _serialize_timestamp(ts: pd.Timestamp) -> str:
+    ts = pd.Timestamp(ts, tz="UTC")
+    return ts.isoformat()
+
+
+def run_scale(
+    symbol: str,
+    *,
+    start: str,
+    end: str,
+    config: ScaleConfig,
+    output_dir: Path,
+    max_retries: int = 6,
+    retry_delay: float = 1.5,
+) -> dict[str, object]:
+    """Execute the full pipeline for a single ``interval``."""
+
+    label = config.label
+    slug = _slugify(f"{symbol}_{label}")
+    scale_dir = ensure_dir(output_dir / slug)
+
+    try:
+        prices = load_yahoo(
+            symbol,
+            start=start,
+            end=end,
+            interval=config.interval,
+            max_retries=max_retries,
+            retry_delay=retry_delay,
+        )
+    except Exception as exc:  # pragma: no cover - network errors in CI
+        return {
+            "label": label,
+            "interval": config.interval,
+            "error": str(exc),
+            "outputs": {},
+            "gaf": {},
+        }
+
+    prices = prices.astype(float)
+    if prices.empty:
+        return {
+            "label": label,
+            "interval": config.interval,
+            "warning": "No data returned for this interval.",
+            "outputs": {},
+            "gaf": {},
+        }
+
+    min_points = config.resolved_min_points()
+    if len(prices) < min_points:
+        return {
+            "label": label,
+            "interval": config.interval,
+            "warning": (
+                f"Only {len(prices)} observations available; need at least {min_points} "
+                "to build sliding windows."
+            ),
+            "observations": int(len(prices)),
+            "outputs": {},
+            "gaf": {
+                "window": int(config.gaf.window),
+                "stride": int(config.gaf.stride),
+            },
+        }
+
+    returns = np.log(prices).diff().dropna()
+    periods_per_year = infer_periods_per_year(prices.index)
+    stats = summarise_prices(prices, returns, periods_per_year=periods_per_year)
+    garch = fit_garch(returns, periods_per_year=periods_per_year)
+    msm_summary = fit_msm(returns)
+    fractal = compute_fractal_metrics(prices, returns)
+
+    price_path = plot_price_series(
+        prices,
+        title=f"{label} close",
+        ylabel="Price",
+        out_dir=scale_dir,
+        filename=f"{slug}_price.png",
+    )
+    returns_path = plot_returns_histogram(
+        returns,
+        out_dir=scale_dir,
+        filename=f"{slug}_returns.png",
+        title=f"{label} log-returns",
+    )
+    garch_path = plot_garch_overlay(
+        returns,
+        garch.conditional_volatility,
+        out_dir=scale_dir,
+        filename=f"{slug}_garch.png",
+    )
+    mfdfa_path = plot_mfdfa_spectrum(
+        fractal.mfdfa,
+        out_dir=scale_dir,
+        filename=f"{slug}_mfdfa.png",
+        title=f"{label} MFDFA spectrum",
+    )
+
+    gaf_summary, gaf_warnings = _gaf_summary(
+        returns,
+        config=config.gaf,
+        out_dir=scale_dir,
+        slug=slug,
+    )
+
+    summary = {
+        "symbol": symbol,
+        "label": label,
+        "interval": config.interval,
+        "periods_per_year": periods_per_year,
+        "data_start": _serialize_timestamp(prices.index[0]),
+        "data_end": _serialize_timestamp(prices.index[-1]),
+        **stats,
+        "garch": garch.summary,
+        "msm": msm_summary,
+        "fractal": fractal.summary,
+        "gaf": gaf_summary,
+        "outputs": {
+            "price": price_path,
+            "returns": returns_path,
+            "garch": garch_path,
+            "mfdfa": mfdfa_path,
+            **gaf_summary.get("sample_images", {}),
+        },
+    }
+
+    warnings: list[str] = []
+    if gaf_warnings:
+        warnings.extend(gaf_warnings)
+    if warnings:
+        summary["warnings"] = warnings
+
+    summary_path = scale_dir / "summary.json"
+    with open(summary_path, "w", encoding="utf-8") as fh:
+        json.dump(summary, fh, indent=2)
+    summary["summary_path"] = str(summary_path)
+    return summary
+
+
+def run_multi_scale_analysis(
+    symbol: str,
+    *,
+    start: str = "1990-01-01",
+    end: str | None = None,
+    scales: Sequence[ScaleConfig] | None = None,
+    output_subdir: str = "multi_scale",
+    max_retries: int = 6,
+    retry_delay: float = 1.5,
+) -> dict[str, dict[str, object]]:
+    """Execute the analysis pipeline for every requested timescale."""
+
+    end = end or pd.Timestamp.utcnow().normalize().strftime("%Y-%m-%d")
+    output_dir = ensure_dir(DEFAULT_OUTPUT_DIR / output_subdir)
+    configs = list(scales or default_scale_configs())
+
+    results: dict[str, dict[str, object]] = {}
+    for cfg in configs:
+        summary = run_scale(
+            symbol,
+            start=start,
+            end=end,
+            config=cfg,
+            output_dir=output_dir,
+            max_retries=max_retries,
+            retry_delay=retry_delay,
+        )
+        slug = _slugify(f"{symbol}_{cfg.label}")
+        results[slug] = summary
+
+    master_path = output_dir / f"{_slugify(symbol)}_multi_scale_summary.json"
+    with open(master_path, "w", encoding="utf-8") as fh:
+        json.dump(results, fh, indent=2)
+
+    return {
+        "results": results,
+        "summary_path": str(master_path),
+    }
+
+
+__all__ = [
+    "GAFScaleConfig",
+    "ScaleConfig",
+    "default_scale_configs",
+    "run_scale",
+    "run_multi_scale_analysis",
+]
+

--- a/src/examples/sp500_daily_analysis.py
+++ b/src/examples/sp500_daily_analysis.py
@@ -11,54 +11,23 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-from arch import arch_model
 
-from fractalfinance.estimators import DFA, MFDFA, RS, StructureFunction, WTMM
+from fractalfinance.analysis.common import (
+    TRADING_DAYS,
+    compute_fractal_metrics,
+    ensure_dir,
+    fit_garch,
+    fit_msm,
+    plot_garch_overlay,
+    plot_mfdfa_spectrum,
+    plot_price_series,
+    plot_returns_histogram,
+    summarise_prices,
+)
 from fractalfinance.io import load_yahoo
-from fractalfinance.models import msm_fit
 from fractalfinance.plotting import DEFAULT_OUTPUT_DIR
-
-TRADING_DAYS = 252
-
-
-def _ensure_dir(path: Path) -> Path:
-    path.mkdir(parents=True, exist_ok=True)
-    return path
-
-
-def _save_fig(fig: plt.Figure, out_dir: Path, filename: str) -> str:
-    _ensure_dir(out_dir)
-    target = out_dir / filename
-    fig.savefig(target, dpi=150, bbox_inches="tight")
-    plt.close(fig)
-    return str(target)
-
-
-def _annualise(daily_value: float) -> float:
-    return float(daily_value * np.sqrt(TRADING_DAYS))
-
-
-def _h_at(mfdfa_res: dict[str, np.ndarray], q: float) -> float | None:
-    qs = mfdfa_res.get("q")
-    hs = mfdfa_res.get("h")
-    if qs is None or hs is None:
-        return None
-    matches = np.where(np.isclose(qs, q))[0]
-    if matches.size == 0:
-        return None
-    return float(hs[matches[0]])
-
-
-def _to_naive(index: pd.Index) -> pd.DatetimeIndex:
-    idx = pd.DatetimeIndex(index)
-    if idx.tz is None:
-        idx = idx.tz_localize("UTC")
-    else:
-        idx = idx.tz_convert("UTC")
-    return idx.tz_localize(None)
 
 
 def run(
@@ -71,114 +40,41 @@ def run(
     """Execute the full analysis and return a nested summary dictionary."""
 
     end = end or pd.Timestamp.utcnow().normalize().strftime("%Y-%m-%d")
-    output_dir = _ensure_dir(DEFAULT_OUTPUT_DIR / output_subdir)
+    output_dir = ensure_dir(DEFAULT_OUTPUT_DIR / output_subdir)
 
     prices = load_yahoo(symbol, start=start, end=end, max_retries=6, retry_delay=1.5)
     prices = prices.astype(float)
     returns = np.log(prices).diff().dropna()
 
-    obs = int(len(returns))
-    span = f"{prices.index[0].date()} → {prices.index[-1].date()}"
-    price_change = float(prices.iloc[-1] / prices.iloc[0] - 1.0)
+    stats = summarise_prices(prices, returns, periods_per_year=TRADING_DAYS)
+    garch = fit_garch(returns, periods_per_year=TRADING_DAYS)
+    msm_summary = fit_msm(returns)
+    fractal = compute_fractal_metrics(prices, returns)
 
-    ann_return = float(returns.mean() * TRADING_DAYS)
-    ann_vol = float(returns.std(ddof=1) * np.sqrt(TRADING_DAYS))
-    skew = float(returns.skew())
-    kurt = float(returns.kurt())
-
-    scaled_returns = (returns * 100).rename("ret_pct")
-    am = arch_model(
-        scaled_returns,
-        mean="AR",
-        lags=1,
-        vol="GARCH",
-        p=1,
-        q=1,
-        dist="normal",
-        rescale=False,
+    price_path = plot_price_series(
+        prices,
+        title="S&P 500 Daily Close",
+        ylabel="Index level",
+        out_dir=output_dir,
+        filename="sp500_price.png",
     )
-    garch_res = am.fit(disp="off")
-    cond_vol = garch_res.conditional_volatility / 100.0
-    forecasts = garch_res.forecast(horizon=5, reindex=False)
-    variance_forecast = forecasts.variance.iloc[-1]
-    daily_forecast = [float(np.sqrt(v) / 100.0) for v in variance_forecast]
-
-    garch_summary = {
-        "params": {k: float(v) for k, v in garch_res.params.items()},
-        "last_cond_vol_daily": float(cond_vol.iloc[-1]),
-        "last_cond_vol_annual": _annualise(float(cond_vol.iloc[-1])),
-        "forecast_daily_vol": daily_forecast,
-        "forecast_annual_vol": [_annualise(v) for v in daily_forecast],
-    }
-
-    msm_params = msm_fit(returns.to_numpy(), K=5)
-    msm_summary = {
-        "sigma2": float(msm_params.sigma2),
-        "m_L": float(msm_params.m_L),
-        "m_H": float(msm_params.m_H),
-        "gamma_1": float(msm_params.gamma_1),
-        "b": float(msm_params.b),
-        "K": int(msm_params.K),
-    }
-
-    rs_res = RS(returns).fit().result_
-    dfa_res = DFA(prices, from_levels=True, auto_range=True).fit().result_
-    struct_res = StructureFunction(returns, from_levels=False).fit().result_
-    mfdfa_res = MFDFA(prices, from_levels=True, auto_range=True).fit().result_
-    wtmm_res = WTMM(returns, from_levels=False).fit().result_
-
-    fractal_summary = {
-        "RS_H": float(rs_res["H"]),
-        "DFA_H": float(dfa_res["H"]),
-        "Structure_H": float(struct_res.H),
-        "Structure_lambda": float(struct_res.lambda_),
-        "Structure_delta_alpha": float(struct_res.delta_alpha),
-        "MFDFA_h2": _h_at(mfdfa_res, 2.0),
-        "MFDFA_width": float(np.max(mfdfa_res["alpha"]) - np.min(mfdfa_res["alpha"])),
-        "WTMM_width": float(np.nanmax(wtmm_res["alpha"]) - np.nanmin(wtmm_res["alpha"])),
-    }
-
-    # ── Plots ──────────────────────────────────────────────────────────
-    idx = _to_naive(prices.index)
-    ret_idx = _to_naive(returns.index)
-
-    fig, ax = plt.subplots(figsize=(10, 4))
-    ax.plot(idx, prices.to_numpy(), color="#1f77b4", lw=1.5)
-    ax.set_title("S&P 500 Daily Close")
-    ax.set_ylabel("Index level")
-    ax.grid(True, alpha=0.3)
-    price_path = _save_fig(fig, output_dir, "sp500_price.png")
-
-    fig, axes = plt.subplots(2, 1, figsize=(10, 6), sharex=True)
-    axes[0].plot(ret_idx, returns.to_numpy() * 100, color="#ff7f0e", lw=0.8)
-    axes[0].set_ylabel("Log-return (%)")
-    axes[0].set_title("Daily log-returns")
-    axes[0].grid(True, alpha=0.3)
-    axes[1].hist(returns.to_numpy() * 100, bins=50, color="#2ca02c", alpha=0.7)
-    axes[1].set_xlabel("Log-return (%)")
-    axes[1].set_ylabel("Frequency")
-    axes[1].grid(True, alpha=0.3)
-    returns_plot = _save_fig(fig, output_dir, "sp500_returns.png")
-
-    fig, ax1 = plt.subplots(figsize=(10, 5))
-    ax1.bar(ret_idx, returns.to_numpy() * 100, color="grey", alpha=0.3, width=1.0)
-    ax1.set_ylabel("Log-return (%)", color="grey")
-    ax1.tick_params(axis="y", labelcolor="grey")
-    ax2 = ax1.twinx()
-    ax2.plot(_to_naive(cond_vol.index), cond_vol * 100, color="#d62728", lw=1.2)
-    ax2.set_ylabel("Cond. volatility (%)", color="#d62728")
-    ax2.tick_params(axis="y", labelcolor="#d62728")
-    ax1.set_title("AR(1)-GARCH(1,1) conditional volatility")
-    ax1.grid(True, alpha=0.3)
-    garch_plot = _save_fig(fig, output_dir, "sp500_garch.png")
-
-    fig, ax = plt.subplots(figsize=(8, 6))
-    ax.plot(mfdfa_res["alpha"], mfdfa_res["f_alpha"], marker="o", lw=1.2)
-    ax.set_xlabel(r"$\alpha$")
-    ax.set_ylabel(r"$f(\alpha)$")
-    ax.set_title("MFDFA singularity spectrum")
-    ax.grid(True, alpha=0.3)
-    mfdfa_plot = _save_fig(fig, output_dir, "sp500_mfdfa.png")
+    returns_plot = plot_returns_histogram(
+        returns,
+        out_dir=output_dir,
+        filename="sp500_returns.png",
+        title="Daily log-returns",
+    )
+    garch_plot = plot_garch_overlay(
+        returns,
+        garch.conditional_volatility,
+        out_dir=output_dir,
+        filename="sp500_garch.png",
+    )
+    mfdfa_plot = plot_mfdfa_spectrum(
+        fractal.mfdfa,
+        out_dir=output_dir,
+        filename="sp500_mfdfa.png",
+    )
 
     outputs = {
         "price_path": price_path,
@@ -189,16 +85,10 @@ def run(
 
     summary = {
         "symbol": symbol,
-        "observations": obs,
-        "span": span,
-        "price_change": price_change,
-        "annualised_return": ann_return,
-        "annualised_volatility": ann_vol,
-        "skew": skew,
-        "excess_kurtosis": kurt,
-        "garch": garch_summary,
+        **stats,
+        "garch": garch.summary,
         "msm": msm_summary,
-        "fractal": fractal_summary,
+        "fractal": fractal.summary,
         "outputs": outputs,
     }
 

--- a/src/fractalfinance/analysis/common.py
+++ b/src/fractalfinance/analysis/common.py
@@ -1,0 +1,358 @@
+"""Shared utilities for running fractal and volatility analyses.
+
+The thesis repository ships a handful of end-to-end workflows that all follow
+the same pattern: fetch prices, derive log-returns, fit volatility models,
+compute fractal diagnostics, and persist a standard collection of plots.  The
+original scripts duplicated a fair amount of bookkeeping (figure handling,
+annualisation helpers, etc.).  This module centralises that logic so more
+advanced runners – e.g. multi-scale comparisons – can reuse the building blocks
+without re-implementing the heavy lifting.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from arch import arch_model
+
+from fractalfinance.estimators import DFA, MFDFA, RS, StructureFunction, WTMM
+from fractalfinance.models import msm_fit
+
+
+TRADING_DAYS = 252.0
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# generic helpers
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def ensure_dir(path: Path) -> Path:
+    """Create ``path`` (including parents) when missing and return it."""
+
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def save_fig(fig: plt.Figure, out_dir: Path, filename: str) -> str:
+    """Persist ``fig`` under ``out_dir``/``filename`` and close the figure."""
+
+    ensure_dir(out_dir)
+    target = out_dir / filename
+    fig.savefig(target, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+    return str(target)
+
+
+def to_naive(index: pd.Index) -> pd.DatetimeIndex:
+    """Return a timezone-naive copy of ``index`` always expressed in UTC."""
+
+    idx = pd.DatetimeIndex(index)
+    if idx.tz is None:
+        idx = idx.tz_localize("UTC")
+    else:
+        idx = idx.tz_convert("UTC")
+    return idx.tz_localize(None)
+
+
+def annualise(daily_value: float, periods_per_year: float) -> float:
+    """Scale a per-period volatility estimate to yearly terms."""
+
+    return float(daily_value * np.sqrt(periods_per_year))
+
+
+def h_at(mfdfa_res: dict[str, np.ndarray], q: float) -> float | None:
+    """Extract the multifractal ``h(q)`` estimate at a specific order."""
+
+    qs = mfdfa_res.get("q")
+    hs = mfdfa_res.get("h")
+    if qs is None or hs is None:
+        return None
+    matches = np.where(np.isclose(qs, q))[0]
+    if matches.size == 0:
+        return None
+    return float(hs[matches[0]])
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# statistical summaries
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def summarise_prices(
+    prices: pd.Series,
+    returns: pd.Series,
+    *,
+    periods_per_year: float,
+) -> dict[str, Any]:
+    """Return headline statistics for ``prices``/``returns``."""
+
+    prices = prices.sort_index()
+    returns = returns.sort_index()
+    obs = int(len(returns))
+    span = f"{prices.index[0].date()} → {prices.index[-1].date()}"
+    price_change = float(prices.iloc[-1] / prices.iloc[0] - 1.0)
+
+    ann_return = float(returns.mean() * periods_per_year)
+    ann_vol = float(returns.std(ddof=1) * np.sqrt(periods_per_year))
+    skew = float(returns.skew())
+    kurt = float(returns.kurt())
+
+    return {
+        "observations": obs,
+        "span": span,
+        "price_change": price_change,
+        "annualised_return": ann_return,
+        "annualised_volatility": ann_vol,
+        "skew": skew,
+        "excess_kurtosis": kurt,
+    }
+
+
+@dataclass(slots=True)
+class GARCHResult:
+    summary: dict[str, Any]
+    conditional_volatility: pd.Series
+    forecast_daily: list[float]
+
+
+def fit_garch(
+    returns: pd.Series,
+    *,
+    periods_per_year: float,
+    mean: str = "AR",
+    lags: int = 1,
+    vol: str = "GARCH",
+    p: int = 1,
+    q: int = 1,
+    dist: str = "normal",
+) -> GARCHResult:
+    """Estimate an AR(1)-GARCH model and return diagnostics."""
+
+    scaled_returns = (returns * 100).rename("ret_pct")
+    am = arch_model(
+        scaled_returns,
+        mean=mean,
+        lags=lags,
+        vol=vol,
+        p=p,
+        q=q,
+        dist=dist,
+        rescale=False,
+    )
+    res = am.fit(disp="off")
+    cond_vol = res.conditional_volatility / 100.0
+    forecasts = res.forecast(horizon=5, reindex=False)
+    variance_forecast = forecasts.variance.iloc[-1]
+    daily_forecast = [float(np.sqrt(v) / 100.0) for v in variance_forecast]
+
+    summary = {
+        "params": {k: float(v) for k, v in res.params.items()},
+        "last_cond_vol_daily": float(cond_vol.iloc[-1]),
+        "last_cond_vol_annual": annualise(cond_vol.iloc[-1], periods_per_year),
+        "forecast_daily_vol": daily_forecast,
+        "forecast_annual_vol": [
+            annualise(v, periods_per_year) for v in daily_forecast
+        ],
+    }
+
+    return GARCHResult(summary, cond_vol, daily_forecast)
+
+
+def fit_msm(returns: pd.Series, *, states: int = 5) -> dict[str, Any]:
+    """Fit the Markov-Switching Multifractal model and summarise parameters."""
+
+    params = msm_fit(returns.to_numpy(), K=states)
+    return {
+        "sigma2": float(params.sigma2),
+        "m_L": float(params.m_L),
+        "m_H": float(params.m_H),
+        "gamma_1": float(params.gamma_1),
+        "b": float(params.b),
+        "K": int(params.K),
+    }
+
+
+@dataclass(slots=True)
+class FractalResult:
+    summary: dict[str, Any]
+    rs: dict[str, Any]
+    dfa: dict[str, Any]
+    structure: Any
+    mfdfa: dict[str, Any]
+    wtmm: dict[str, Any]
+
+
+def compute_fractal_metrics(
+    prices: pd.Series,
+    returns: pd.Series,
+    *,
+    structure_from_levels: bool = False,
+) -> FractalResult:
+    """Run the suite of fractal estimators and package key diagnostics."""
+
+    rs_res = RS(returns).fit().result_
+    dfa_res = DFA(prices, from_levels=True, auto_range=True).fit().result_
+    struct_res = StructureFunction(
+        returns,
+        from_levels=structure_from_levels,
+    ).fit().result_
+    mfdfa_res = MFDFA(prices, from_levels=True, auto_range=True).fit().result_
+    wtmm_res = WTMM(returns, from_levels=structure_from_levels).fit().result_
+
+    summary = {
+        "RS_H": float(rs_res["H"]),
+        "DFA_H": float(dfa_res["H"]),
+        "Structure_H": float(struct_res.H),
+        "Structure_lambda": float(struct_res.lambda_),
+        "Structure_delta_alpha": float(struct_res.delta_alpha),
+        "MFDFA_h2": h_at(mfdfa_res, 2.0),
+        "MFDFA_width": float(np.max(mfdfa_res["alpha"]) - np.min(mfdfa_res["alpha"])),
+        "WTMM_width": float(
+            np.nanmax(wtmm_res["alpha"]) - np.nanmin(wtmm_res["alpha"])
+        ),
+    }
+
+    return FractalResult(summary, rs_res, dfa_res, struct_res, mfdfa_res, wtmm_res)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# plotting helpers
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def plot_price_series(
+    prices: pd.Series,
+    *,
+    title: str,
+    ylabel: str,
+    out_dir: Path,
+    filename: str,
+) -> str:
+    fig, ax = plt.subplots(figsize=(10, 4))
+    ax.plot(to_naive(prices.index), prices.to_numpy(), color="#1f77b4", lw=1.5)
+    ax.set_title(title)
+    ax.set_ylabel(ylabel)
+    ax.grid(True, alpha=0.3)
+    return save_fig(fig, out_dir, filename)
+
+
+def plot_returns_histogram(
+    returns: pd.Series,
+    *,
+    out_dir: Path,
+    filename: str,
+    title: str = "Log-returns",
+) -> str:
+    data = returns.to_numpy() * 100
+    idx = to_naive(returns.index)
+    fig, axes = plt.subplots(2, 1, figsize=(10, 6), sharex=True)
+    axes[0].plot(idx, data, color="#ff7f0e", lw=0.8)
+    axes[0].set_ylabel("Log-return (%)")
+    axes[0].set_title(title)
+    axes[0].grid(True, alpha=0.3)
+    axes[1].hist(data, bins=50, color="#2ca02c", alpha=0.7)
+    axes[1].set_xlabel("Log-return (%)")
+    axes[1].set_ylabel("Frequency")
+    axes[1].grid(True, alpha=0.3)
+    return save_fig(fig, out_dir, filename)
+
+
+def plot_garch_overlay(
+    returns: pd.Series,
+    cond_vol: pd.Series,
+    *,
+    out_dir: Path,
+    filename: str,
+    title: str = "AR(1)-GARCH(1,1) conditional volatility",
+) -> str:
+    fig, ax1 = plt.subplots(figsize=(10, 5))
+    ax1.bar(
+        to_naive(returns.index),
+        returns.to_numpy() * 100,
+        color="grey",
+        alpha=0.3,
+        width=1.0,
+    )
+    ax1.set_ylabel("Log-return (%)", color="grey")
+    ax1.tick_params(axis="y", labelcolor="grey")
+    ax2 = ax1.twinx()
+    ax2.plot(to_naive(cond_vol.index), cond_vol * 100, color="#d62728", lw=1.2)
+    ax2.set_ylabel("Cond. volatility (%)", color="#d62728")
+    ax2.tick_params(axis="y", labelcolor="#d62728")
+    ax1.set_title(title)
+    ax1.grid(True, alpha=0.3)
+    return save_fig(fig, out_dir, filename)
+
+
+def plot_mfdfa_spectrum(
+    mfdfa_res: dict[str, np.ndarray],
+    *,
+    out_dir: Path,
+    filename: str,
+    title: str = "MFDFA singularity spectrum",
+) -> str:
+    fig, ax = plt.subplots(figsize=(8, 6))
+    ax.plot(mfdfa_res["alpha"], mfdfa_res["f_alpha"], marker="o", lw=1.2)
+    ax.set_xlabel(r"$\alpha$")
+    ax.set_ylabel(r"$f(\alpha)$")
+    ax.set_title(title)
+    ax.grid(True, alpha=0.3)
+    return save_fig(fig, out_dir, filename)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# timescale inference
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def infer_periods_per_year(index: pd.Index) -> float:
+    """Guess the appropriate annualisation factor from the sample spacing."""
+
+    idx = pd.DatetimeIndex(index).sort_values()
+    if idx.size < 2:
+        return TRADING_DAYS
+    deltas = idx.to_series().diff().dropna().dt.total_seconds().to_numpy()
+    median_seconds = float(np.median(deltas)) if deltas.size else 0.0
+    day = 24 * 3600
+
+    if median_seconds <= 0:
+        return TRADING_DAYS
+    if 0.8 * day <= median_seconds <= 1.5 * day:
+        return TRADING_DAYS
+    if 5 * day <= median_seconds <= 10 * day:
+        return 52.0
+    if 20 * day <= median_seconds <= 40 * day:
+        return 12.0
+    if median_seconds < day:
+        periods_per_day = day / median_seconds
+        return periods_per_day * TRADING_DAYS
+    seconds_per_year = 365.25 * day
+    return seconds_per_year / median_seconds
+
+
+__all__ = [
+    "TRADING_DAYS",
+    "GARCHResult",
+    "FractalResult",
+    "ensure_dir",
+    "save_fig",
+    "to_naive",
+    "annualise",
+    "h_at",
+    "summarise_prices",
+    "fit_garch",
+    "fit_msm",
+    "compute_fractal_metrics",
+    "plot_price_series",
+    "plot_returns_histogram",
+    "plot_garch_overlay",
+    "plot_mfdfa_spectrum",
+    "infer_periods_per_year",
+]
+

--- a/src/fractalfinance/cli.py
+++ b/src/fractalfinance/cli.py
@@ -251,6 +251,63 @@ def multi_asset_cmd(
         typer.echo(json.dumps(results, indent=2))
 
 
+@examples_app.command("multi-scale")
+def multi_scale_cmd(
+    symbol: str = typer.Argument("^GSPC", help="Yahoo Finance ticker symbol."),
+    start: str = typer.Option("1990-01-01", help="Start date (YYYY-MM-DD)."),
+    end: Optional[str] = typer.Option(None, help="End date (defaults to today)."),
+    output_subdir: str = typer.Option(
+        "multi_scale", help="Folder under analysis_outputs for the run."
+    ),
+    include_intraday: bool = typer.Option(
+        True, help="Include minute/hourly intervals in the comparison."
+    ),
+    show_summary: bool = typer.Option(
+        False, help="Print the combined JSON summary after finishing the run."
+    ),
+) -> None:
+    """Run the multi-timescale analysis pipeline for ``symbol``."""
+
+    _ensure_experiments_on_path()
+    from examples import multi_scale_analysis
+
+    scales = multi_scale_analysis.default_scale_configs()
+    if not include_intraday:
+        skip = {"1m", "5m", "15m", "1h"}
+        scales = [cfg for cfg in scales if cfg.interval not in skip]
+
+    result = multi_scale_analysis.run_multi_scale_analysis(
+        symbol,
+        start=start,
+        end=end,
+        scales=scales,
+        output_subdir=output_subdir,
+    )
+
+    summary_path = result.get("summary_path")
+    if summary_path:
+        typer.echo(f"Summary written to {summary_path}")
+
+    for slug, summary in result.get("results", {}).items():
+        label = summary.get("label", slug)
+        summary_path = summary.get("summary_path")
+        typer.echo(f"{label} summary: {summary_path}")
+        outputs = summary.get("outputs", {})
+        if outputs:
+            typer.echo(f"{label} figures:")
+            for name, path in outputs.items():
+                typer.echo(f"  {name}: {path}")
+        if summary.get("warnings"):
+            typer.echo("  warnings:")
+            for warn in summary["warnings"]:
+                typer.echo(f"    - {warn}")
+        if summary.get("error"):
+            typer.echo(f"  error: {summary['error']}")
+
+    if show_summary:
+        typer.echo(json.dumps(result, indent=2))
+
+
 app.add_typer(examples_app, name="examples")
 
 

--- a/src/fractalfinance/gaf/dataset.py
+++ b/src/fractalfinance/gaf/dataset.py
@@ -25,6 +25,7 @@ class GAFWindowDataset(Dataset):
         scale: str = "symmetric",
         resample: str = "paa",
         to_uint8: bool = False,
+        image_size: int | None = None,
         labels: np.ndarray | None = None,
         transform: Callable[[torch.Tensor], torch.Tensor] | None = None,
     ) -> None:
@@ -40,6 +41,7 @@ class GAFWindowDataset(Dataset):
         self.scale = scale
         self.resample = resample
         self.to_uint8 = bool(to_uint8)
+        self.image_size = int(image_size) if image_size is not None else None
         self.transform = transform
         if self.win <= 0 or self.stride <= 0:
             raise ValueError("win and stride must be positive integers")
@@ -61,6 +63,7 @@ class GAFWindowDataset(Dataset):
             scale=self.scale,
             resample=self.resample,
             to_uint8=self.to_uint8,
+            image_size=self.image_size,
         )
         tensor = torch.tensor(cube)
         if not self.to_uint8:


### PR DESCRIPTION
## Summary
- extract shared plotting, volatility, and fractal helpers into `fractalfinance.analysis.common`
- refactor the existing S&P 500 and asset pipelines to reuse the common utilities
- introduce a multi-timescale analysis workflow with CLI entry point and configurable GAF image sizes

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc0b9f95248333a1e410e75b75a7d1