### PR TITLE
Expand multi-asset fractal diagnostics

### DIFF
--- a/src/examples/asset_analysis.py
+++ b/src/examples/asset_analysis.py
@@ -24,10 +24,14 @@ from fractalfinance.analysis.common import (
     ensure_dir,
     fit_garch,
     fit_msm,
+    plot_dfa_fluctuation,
     plot_garch_overlay,
     plot_mfdfa_spectrum,
     plot_price_series,
+    plot_rs_scaling,
     plot_returns_histogram,
+    plot_structure_function_summary,
+    plot_wtmm_spectrum,
     summarise_prices,
 )
 from fractalfinance.io import load_yahoo
@@ -133,12 +137,36 @@ def run_asset_analysis(
         out_dir=output_dir,
         filename=f"{slug}_mfdfa.png",
     )
+    rs_plot = plot_rs_scaling(
+        fractal.rs,
+        out_dir=output_dir,
+        filename=f"{slug}_rs.png",
+    )
+    dfa_plot = plot_dfa_fluctuation(
+        fractal.dfa,
+        out_dir=output_dir,
+        filename=f"{slug}_dfa.png",
+    )
+    structure_plot = plot_structure_function_summary(
+        fractal.structure,
+        out_dir=output_dir,
+        filename=f"{slug}_structure.png",
+    )
+    wtmm_plot = plot_wtmm_spectrum(
+        fractal.wtmm,
+        out_dir=output_dir,
+        filename=f"{slug}_wtmm.png",
+    )
 
     outputs = {
         "price_path": price_path,
         "returns": returns_plot,
         "garch": garch_plot,
         "mfdfa": mfdfa_plot,
+        "rs": rs_plot,
+        "dfa": dfa_plot,
+        "structure": structure_plot,
+        "wtmm": wtmm_plot,
     }
 
     summary = {

--- a/src/examples/multi_scale_analysis.py
+++ b/src/examples/multi_scale_analysis.py
@@ -21,10 +21,14 @@ from fractalfinance.analysis.common import (
     fit_garch,
     fit_msm,
     infer_periods_per_year,
+    plot_dfa_fluctuation,
     plot_garch_overlay,
     plot_mfdfa_spectrum,
     plot_price_series,
+    plot_rs_scaling,
     plot_returns_histogram,
+    plot_structure_function_summary,
+    plot_wtmm_spectrum,
     summarise_prices,
 )
 from fractalfinance.gaf.dataset import GAFWindowDataset
@@ -489,6 +493,34 @@ def run_scale(
             title=f"{label} MFDFA spectrum",
         )
         outputs["mfdfa"] = mfdfa_path
+        rs_path = plot_rs_scaling(
+            fractal_result.rs,
+            out_dir=scale_dir,
+            filename=f"{slug}_rs.png",
+            title=f"{label} R/S scaling",
+        )
+        outputs["rs"] = rs_path
+        dfa_path = plot_dfa_fluctuation(
+            fractal_result.dfa,
+            out_dir=scale_dir,
+            filename=f"{slug}_dfa.png",
+            title=f"{label} DFA fluctuation",
+        )
+        outputs["dfa"] = dfa_path
+        structure_path = plot_structure_function_summary(
+            fractal_result.structure,
+            out_dir=scale_dir,
+            filename=f"{slug}_structure.png",
+            title=f"{label} structure-function",
+        )
+        outputs["structure"] = structure_path
+        wtmm_path = plot_wtmm_spectrum(
+            fractal_result.wtmm,
+            out_dir=scale_dir,
+            filename=f"{slug}_wtmm.png",
+            title=f"{label} WTMM spectrum",
+        )
+        outputs["wtmm"] = wtmm_path
 
 
     gaf_summary, gaf_warnings = _gaf_summary(

--- a/src/examples/sp500_daily_analysis.py
+++ b/src/examples/sp500_daily_analysis.py
@@ -20,10 +20,14 @@ from fractalfinance.analysis.common import (
     ensure_dir,
     fit_garch,
     fit_msm,
+    plot_dfa_fluctuation,
     plot_garch_overlay,
     plot_mfdfa_spectrum,
     plot_price_series,
+    plot_rs_scaling,
     plot_returns_histogram,
+    plot_structure_function_summary,
+    plot_wtmm_spectrum,
     summarise_prices,
 )
 from fractalfinance.io import load_yahoo
@@ -75,12 +79,36 @@ def run(
         out_dir=output_dir,
         filename="sp500_mfdfa.png",
     )
+    rs_plot = plot_rs_scaling(
+        fractal.rs,
+        out_dir=output_dir,
+        filename="sp500_rs.png",
+    )
+    dfa_plot = plot_dfa_fluctuation(
+        fractal.dfa,
+        out_dir=output_dir,
+        filename="sp500_dfa.png",
+    )
+    structure_plot = plot_structure_function_summary(
+        fractal.structure,
+        out_dir=output_dir,
+        filename="sp500_structure.png",
+    )
+    wtmm_plot = plot_wtmm_spectrum(
+        fractal.wtmm,
+        out_dir=output_dir,
+        filename="sp500_wtmm.png",
+    )
 
     outputs = {
         "price_path": price_path,
         "returns": returns_plot,
         "garch": garch_plot,
         "mfdfa": mfdfa_plot,
+        "rs": rs_plot,
+        "dfa": dfa_plot,
+        "structure": structure_plot,
+        "wtmm": wtmm_plot,
     }
 
     summary = {

--- a/src/fractalfinance/estimators/dfa.py
+++ b/src/fractalfinance/estimators/dfa.py
@@ -117,8 +117,21 @@ class DFA(BaseEstimator):
             if self.auto_range
             else slice(0, len(log_s))
         )
-        H, _ = np.polyfit(log_s[sl], log_F[sl], 1)
-        result = {"H": float(H), "scales": scales[mask][sl]}
+        slope, intercept = np.polyfit(log_s[sl], log_F[sl], 1)
+        fit_start = int(sl.start or 0)
+        fit_stop = int(sl.stop or len(log_s))
+        fluct = np.sqrt(F2[mask])
+        result = {
+            "H": float(slope),
+            "intercept": float(intercept),
+            "scales": scales[mask],
+            "fluctuation": fluct,
+            "log_scales": log_s,
+            "log_fluct": log_F,
+            "fit_start": fit_start,
+            "fit_stop": fit_stop,
+            "fit_scales": scales[mask][sl],
+        }
 
         if self.n_boot > 0:
             boot = []

--- a/src/fractalfinance/estimators/rs.py
+++ b/src/fractalfinance/estimators/rs.py
@@ -79,8 +79,16 @@ class RS(BaseEstimator):
         RS_arr = np.asarray(RS_vals, dtype=float)
         if logn_arr.size < 2:
             raise RuntimeError("RS: not enough valid window sizes for regression.")
-        H, _ = np.polyfit(logn_arr, np.log(RS_arr), 1)
-        result = {"H": float(H)}
+        slope, intercept = np.polyfit(logn_arr, np.log(RS_arr), 1)
+        H = float(slope)
+        result = {
+            "H": H,
+            "intercept": float(intercept),
+            "log_scales": logn_arr,
+            "log_rs": np.log(RS_arr),
+            "scales": np.exp(logn_arr),
+            "rs": RS_arr,
+        }
 
         if n_surrogates > 0:
             n_surrogates = int(n_surrogates)


### PR DESCRIPTION
## Summary
- extend the R/S and DFA estimators to retain the log–log diagnostics needed for plotting
- add reusable plotting helpers for R/S, DFA, structure-function, and WTMM spectra
- update the S&P 500, multi-asset, and multi-scale analysis pipelines to generate plots for all fractal models

## Testing
- PYTHONPATH=src poetry run pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd78127b888333b4ccddd013b8526b