### PR TITLE
Expand multi-asset lookbacks

### DIFF
--- a/src/examples/__init__.py
+++ b/src/examples/__init__.py
@@ -1,5 +1,10 @@
 """Example analysis workflows bundled with the project."""
 
-from . import asset_analysis, multi_scale_analysis, sp500_daily_analysis
+from . import asset_analysis, multi_scale_analysis, multi_scale_gaf, sp500_daily_analysis
 
-__all__ = ["asset_analysis", "multi_scale_analysis", "sp500_daily_analysis"]
+__all__ = [
+    "asset_analysis",
+    "multi_scale_analysis",
+    "multi_scale_gaf",
+    "sp500_daily_analysis",
+]

--- a/src/examples/asset_analysis.py
+++ b/src/examples/asset_analysis.py
@@ -192,13 +192,15 @@ def run_asset_analysis(
 
 
 def _default_configs() -> list[AssetRunConfig]:
+    default_start = "1900-01-01"
+
     return [
         AssetRunConfig(
             key="sp500",
             symbol="^GSPC",
             label="S&P 500 Index",
             asset_type="equity_index",
-            start="2020-01-01",
+            start=default_start,
             annualisation_days=252.0,
             price_ylabel="Index level",
             output_subdir="sp500_daily",
@@ -212,7 +214,7 @@ def _default_configs() -> list[AssetRunConfig]:
             symbol="BTC-USD",
             label="Bitcoin / US Dollar",
             asset_type="crypto",
-            start="2020-01-01",
+            start=default_start,
             annualisation_days=365.0,
             price_ylabel="Price (USD)",
             output_subdir="bitcoin_daily",
@@ -226,7 +228,7 @@ def _default_configs() -> list[AssetRunConfig]:
             symbol="EURUSD=X",
             label="EUR/USD",
             asset_type="forex",
-            start="2020-01-01",
+            start=default_start,
             annualisation_days=260.0,
             price_ylabel="USD per EUR",
             output_subdir="fx_eurusd_daily",
@@ -240,7 +242,7 @@ def _default_configs() -> list[AssetRunConfig]:
             symbol="AAPL",
             label="Apple Inc.",
             asset_type="equity",
-            start="2020-01-01",
+            start=default_start,
             annualisation_days=252.0,
             price_ylabel="Price (USD)",
             output_subdir="apple_daily",
@@ -250,7 +252,7 @@ def _default_configs() -> list[AssetRunConfig]:
             symbol="TLT",
             label="iShares 20+ Year Treasury Bond ETF",
             asset_type="bond",
-            start="2020-01-01",
+            start=default_start,
             annualisation_days=252.0,
             price_ylabel="Price (USD)",
             output_subdir="bond_tlt_daily",

--- a/src/examples/multi_scale_gaf.py
+++ b/src/examples/multi_scale_gaf.py
@@ -1,0 +1,297 @@
+"""Multi-asset, multi-scale Gramian Angular Field generation without fractal models."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+import numpy as np
+import pandas as pd
+
+from fractalfinance.analysis.common import ensure_dir
+from fractalfinance.io import load_yahoo
+from fractalfinance.plotting import DEFAULT_OUTPUT_DIR
+
+from .multi_scale_analysis import (
+    GAFScaleConfig,
+    ScaleConfig,
+    default_scale_configs,
+    gaf_summary,
+    serialize_timestamp,
+    slugify,
+)
+
+
+@dataclass(slots=True)
+class AssetConfig:
+    """Describe a single asset to analyse via GAF."""
+
+    key: str
+    symbol: str
+    start: str
+    end: str | None = None
+
+
+DEFAULT_LONG_LOOKBACK = "1900-01-01"
+
+
+def default_assets() -> list[AssetConfig]:
+    """Return the five assets used in the thesis multi-asset runs."""
+
+    return [
+        AssetConfig(key="sp500", symbol="^GSPC", start=DEFAULT_LONG_LOOKBACK),
+        AssetConfig(key="bitcoin", symbol="BTC-USD", start=DEFAULT_LONG_LOOKBACK),
+        AssetConfig(key="forex", symbol="EURUSD=X", start=DEFAULT_LONG_LOOKBACK),
+        AssetConfig(key="apple", symbol="AAPL", start=DEFAULT_LONG_LOOKBACK),
+        AssetConfig(key="bond", symbol="TLT", start=DEFAULT_LONG_LOOKBACK),
+    ]
+
+
+def _serialise_span(index: pd.Index) -> str:
+    idx = pd.DatetimeIndex(index).sort_values()
+    if idx.empty:
+        return ""
+    return f"{idx[0].date()} → {idx[-1].date()}"
+
+
+def _compute_returns(prices: pd.Series) -> pd.Series:
+    return np.log(prices).diff().dropna()
+
+
+def run_gaf_scale(
+    symbol: str,
+    *,
+    start: str,
+    end: str,
+    config: ScaleConfig,
+    output_dir: Path,
+    max_retries: int = 6,
+    retry_delay: float = 1.5,
+) -> dict[str, object]:
+    """Generate GAF cubes for a single Yahoo! Finance interval."""
+
+    slug = slugify(f"{symbol}_{config.label}")
+    scale_dir = ensure_dir(output_dir / slug)
+
+    try:
+        prices = load_yahoo(
+            symbol,
+            start=start,
+            end=end,
+            interval=config.interval,
+            max_retries=max_retries,
+            retry_delay=retry_delay,
+        )
+    except Exception as exc:  # pragma: no cover - network dependencies
+        return {
+            "label": config.label,
+            "interval": config.interval,
+            "error": str(exc),
+            "warnings": [str(exc)],
+            "gaf": {},
+            "outputs": {},
+        }
+
+    prices = prices.astype(float).dropna()
+    if prices.empty:
+        return {
+            "label": config.label,
+            "interval": config.interval,
+            "warnings": ["No data returned for this interval."],
+            "gaf": {},
+            "outputs": {},
+        }
+
+    warnings: list[str] = []
+    min_points = config.resolved_min_points()
+    if len(prices) < min_points:
+        warnings.append(
+            "Only {count} observations available; {needed} recommended to populate"
+            " {window}-point windows.".format(
+                count=len(prices),
+                needed=min_points,
+                window=config.gaf.window,
+            )
+        )
+
+    returns = _compute_returns(prices)
+    gaf_info, gaf_warnings = gaf_summary(
+        returns,
+        config=config.gaf,
+        out_dir=scale_dir,
+        slug=slug,
+    )
+
+    if gaf_warnings:
+        warnings.extend(gaf_warnings)
+
+    summary: dict[str, object] = {
+        "symbol": symbol,
+        "label": config.label,
+        "interval": config.interval,
+        "observations": int(len(prices)),
+        "span": _serialise_span(prices.index),
+        "data_start": serialize_timestamp(prices.index[0]),
+        "data_end": serialize_timestamp(prices.index[-1]),
+        "gaf": gaf_info,
+        "outputs": gaf_info.get("sample_images", {}),
+    }
+
+    if warnings:
+        summary["warnings"] = warnings
+
+    summary_path = scale_dir / "gaf_summary.json"
+    with open(summary_path, "w", encoding="utf-8") as fh:
+        json.dump(summary, fh, indent=2)
+    summary["summary_path"] = str(summary_path)
+    return summary
+
+
+def run_multi_scale_gaf(
+    symbol: str,
+    *,
+    start: str,
+    end: str | None = None,
+    scales: Sequence[ScaleConfig] | None = None,
+    output_subdir: str = "multi_scale_gaf",
+    include_intraday: bool = True,
+    max_retries: int = 6,
+    retry_delay: float = 1.5,
+) -> dict[str, object]:
+    """Run the GAF-only workflow across all configured scales."""
+
+    end = end or pd.Timestamp.utcnow().normalize().strftime("%Y-%m-%d")
+    output_dir = ensure_dir(DEFAULT_OUTPUT_DIR / output_subdir)
+
+    configs = list(scales or default_scale_configs())
+    if not include_intraday:
+        skip = {"1m", "5m", "15m", "1h"}
+        configs = [cfg for cfg in configs if cfg.interval not in skip]
+
+    results: dict[str, dict[str, object]] = {}
+    for cfg in configs:
+        summary = run_gaf_scale(
+            symbol,
+            start=start,
+            end=end,
+            config=cfg,
+            output_dir=output_dir,
+            max_retries=max_retries,
+            retry_delay=retry_delay,
+        )
+        slug = slugify(f"{symbol}_{cfg.label}")
+        results[slug] = summary
+
+    comparison_rows: list[dict[str, object]] = []
+    image_recommendations: list[dict[str, object]] = []
+
+    for summary in results.values():
+        if not isinstance(summary, dict):
+            continue
+
+        gaf_info = summary.get("gaf") or {}
+        if not gaf_info:
+            continue
+
+        row = {
+            "label": summary.get("label"),
+            "interval": summary.get("interval"),
+            "observations": summary.get("observations"),
+            "span": summary.get("span"),
+            "gaf_windows": gaf_info.get("windows"),
+            "gaf_channels": gaf_info.get("channels"),
+            "gaf_image_size": gaf_info.get("image_size"),
+            "gaf_window_span_pretty": gaf_info.get("window_span_pretty"),
+            "gaf_label_distribution": gaf_info.get("label_distribution"),
+            "gaf_label_distribution_share": gaf_info.get("label_distribution_share"),
+            "gaf_label_mode": gaf_info.get("label_mode"),
+            "gaf_neutral_threshold": gaf_info.get("neutral_threshold"),
+            "gaf_quantile_bins": gaf_info.get("quantile_bins"),
+        }
+        comparison_rows.append(row)
+
+        evaluation = gaf_info.get("image_evaluation") or {}
+        if evaluation and evaluation.get("status") != "ok":
+            recommendation = {
+                "label": summary.get("label"),
+                "interval": summary.get("interval"),
+                **evaluation,
+            }
+            image_recommendations.append(recommendation)
+
+    master_summary = {
+        "symbol": symbol,
+        "start": start,
+        "end": end,
+        "scales": comparison_rows,
+        "image_recommendations": image_recommendations,
+        "results": results,
+    }
+
+    master_path = output_dir / f"{slugify(symbol)}_multi_scale_gaf_summary.json"
+    with open(master_path, "w", encoding="utf-8") as fh:
+        json.dump(master_summary, fh, indent=2)
+    master_summary["summary_path"] = str(master_path)
+
+    return master_summary
+
+
+def run_multi_asset_gaf(
+    assets: Sequence[AssetConfig] | None = None,
+    *,
+    base_output_subdir: str = "multi_asset_gaf",
+    include_intraday: bool = True,
+    max_retries: int = 6,
+    retry_delay: float = 1.5,
+) -> dict[str, object]:
+    """Run the GAF-only workflow for the supplied assets."""
+
+    asset_list = list(assets or default_assets())
+    base_dir = ensure_dir(DEFAULT_OUTPUT_DIR / base_output_subdir)
+    combined_results: dict[str, object] = {}
+    recommendations: list[dict[str, object]] = []
+
+    for asset in asset_list:
+        subdir = Path(base_output_subdir) / asset.key
+        result = run_multi_scale_gaf(
+            asset.symbol,
+            start=asset.start,
+            end=asset.end,
+            output_subdir=str(subdir),
+            include_intraday=include_intraday,
+            max_retries=max_retries,
+            retry_delay=retry_delay,
+        )
+        combined_results[asset.key] = result
+        recs = result.get("image_recommendations") or []
+        for rec in recs:
+            rec_with_asset = {"asset": asset.key, **rec}
+            recommendations.append(rec_with_asset)
+
+    overview = {
+        "base_output_dir": str(base_dir),
+        "assets": [asset.__dict__ for asset in asset_list],
+        "results": combined_results,
+        "image_recommendations": recommendations,
+    }
+
+    overview_path = base_dir / "multi_asset_gaf_summary.json"
+    with open(overview_path, "w", encoding="utf-8") as fh:
+        json.dump(overview, fh, indent=2)
+    overview["summary_path"] = str(overview_path)
+
+    return overview
+
+
+__all__ = [
+    "AssetConfig",
+    "GAFScaleConfig",
+    "ScaleConfig",
+    "default_assets",
+    "default_scale_configs",
+    "run_gaf_scale",
+    "run_multi_scale_gaf",
+    "run_multi_asset_gaf",
+]

--- a/src/fractalfinance/cli.py
+++ b/src/fractalfinance/cli.py
@@ -156,7 +156,7 @@ def multi_asset_cmd(
         "S&P 500 Index", help="Display label for the equity index leg.",
     ),
     sp500_start: str = typer.Option(
-        "2020-01-01", help="Start date for the equity index run (YYYY-MM-DD).",
+        "1900-01-01", help="Start date for the equity index run (YYYY-MM-DD).",
     ),
     sp500_end: Optional[str] = typer.Option(
         None, help="Optional end date for the equity index run (YYYY-MM-DD).",
@@ -165,7 +165,7 @@ def multi_asset_cmd(
         "BTC-USD", help="Yahoo Finance ticker for the Bitcoin pair."
     ),
     bitcoin_start: str = typer.Option(
-        "2020-01-01", help="Start date for the Bitcoin run (YYYY-MM-DD)."
+        "1900-01-01", help="Start date for the Bitcoin run (YYYY-MM-DD)."
     ),
     bitcoin_end: Optional[str] = typer.Option(
         None, help="Optional end date for the Bitcoin run (YYYY-MM-DD)."
@@ -177,13 +177,13 @@ def multi_asset_cmd(
         "EUR/USD", help="Display label for the FX pair."
     ),
     forex_start: str = typer.Option(
-        "2020-01-01", help="Start date for the FX run (YYYY-MM-DD)."
+        "1900-01-01", help="Start date for the FX run (YYYY-MM-DD)."
     ),
     forex_end: Optional[str] = typer.Option(
         None, help="Optional end date for the FX run (YYYY-MM-DD)."
     ),
     apple_start: str = typer.Option(
-        "2020-01-01", help="Start date for the Apple run (YYYY-MM-DD)."
+        "1900-01-01", help="Start date for the Apple run (YYYY-MM-DD)."
     ),
     apple_end: Optional[str] = typer.Option(
         None, help="Optional end date for the Apple run (YYYY-MM-DD)."
@@ -196,7 +196,7 @@ def multi_asset_cmd(
         help="Display label for the long-term bond instrument.",
     ),
     bond_start: str = typer.Option(
-        "2020-01-01", help="Start date for the bond run (YYYY-MM-DD)."
+        "1900-01-01", help="Start date for the bond run (YYYY-MM-DD)."
     ),
     bond_end: Optional[str] = typer.Option(
         None, help="Optional end date for the bond run (YYYY-MM-DD)."
@@ -344,6 +344,83 @@ def multi_scale_cmd(
     if show_summary:
         typer.echo(json.dumps(result, indent=2))
 
+
+@examples_app.command("multi-asset-gaf")
+def multi_asset_gaf_cmd(
+    base_output_subdir: str = typer.Option(
+        "multi_asset_gaf",
+        help="Root folder under analysis_outputs to store multi-asset GAF runs.",
+    ),
+    include_intraday: bool = typer.Option(
+        True, help="Include minute/hourly intervals when generating GAF cubes."
+    ),
+    show_summary: bool = typer.Option(
+        False, help="Print the aggregated JSON summary after finishing the run."
+    ),
+    sp500_symbol: str = typer.Option("^GSPC", help="Yahoo Finance ticker for the equity leg."),
+    sp500_start: str = typer.Option("1900-01-01", help="Start date for the equity leg."),
+    sp500_end: Optional[str] = typer.Option(None, help="Optional end date for the equity leg."),
+    bitcoin_symbol: str = typer.Option("BTC-USD", help="Yahoo Finance ticker for the Bitcoin leg."),
+    bitcoin_start: str = typer.Option("1900-01-01", help="Start date for the Bitcoin leg."),
+    bitcoin_end: Optional[str] = typer.Option(None, help="Optional end date for the Bitcoin leg."),
+    forex_symbol: str = typer.Option("EURUSD=X", help="Yahoo Finance ticker for the FX leg."),
+    forex_start: str = typer.Option("1900-01-01", help="Start date for the FX leg."),
+    forex_end: Optional[str] = typer.Option(None, help="Optional end date for the FX leg."),
+    apple_symbol: str = typer.Option("AAPL", help="Yahoo Finance ticker for the single-stock leg."),
+    apple_start: str = typer.Option("1900-01-01", help="Start date for the single-stock leg."),
+    apple_end: Optional[str] = typer.Option(None, help="Optional end date for the single-stock leg."),
+    bond_symbol: str = typer.Option("TLT", help="Yahoo Finance ticker for the bond proxy."),
+    bond_start: str = typer.Option("1900-01-01", help="Start date for the bond proxy."),
+    bond_end: Optional[str] = typer.Option(None, help="Optional end date for the bond proxy."),
+) -> None:
+    """Run the multi-asset GAF-only workflow across all default instruments."""
+
+    _ensure_experiments_on_path()
+    from examples import multi_scale_gaf
+
+    assets = [
+        multi_scale_gaf.AssetConfig(
+            key="sp500", symbol=sp500_symbol, start=sp500_start, end=sp500_end
+        ),
+        multi_scale_gaf.AssetConfig(
+            key="bitcoin",
+            symbol=bitcoin_symbol,
+            start=bitcoin_start,
+            end=bitcoin_end,
+        ),
+        multi_scale_gaf.AssetConfig(
+            key="forex", symbol=forex_symbol, start=forex_start, end=forex_end
+        ),
+        multi_scale_gaf.AssetConfig(
+            key="apple", symbol=apple_symbol, start=apple_start, end=apple_end
+        ),
+        multi_scale_gaf.AssetConfig(
+            key="bond", symbol=bond_symbol, start=bond_start, end=bond_end
+        ),
+    ]
+
+    overview = multi_scale_gaf.run_multi_asset_gaf(
+        assets,
+        base_output_subdir=base_output_subdir,
+        include_intraday=include_intraday,
+    )
+
+    summary_path = overview.get("summary_path")
+    if summary_path:
+        typer.echo(f"Multi-asset GAF summary written to {summary_path}")
+
+    for asset_key, result in overview.get("results", {}).items():
+        if not isinstance(result, dict):
+            continue
+        asset_summary = result.get("summary_path")
+        if asset_summary:
+            typer.echo(f"{asset_key}: summary at {asset_summary}")
+        recs = result.get("image_recommendations") or []
+        if recs:
+            typer.echo(f"  {asset_key} image recommendations: {len(recs)} warnings")
+
+    if show_summary:
+        typer.echo(json.dumps(overview, indent=2))
 
 app.add_typer(examples_app, name="examples")
 


### PR DESCRIPTION
## Summary
- extend the default multi-asset configurations to request data back to 1900 so the S&P 500 and peers use the longest available history
- align the CLI defaults for the multi-asset fractal and GAF commands with the longer lookback to avoid truncated windows in downstream summaries
- expose the long-lookback constant in the GAF workflow so orchestrated runs share the same baseline horizon

## Testing
- PYTHONPATH=src pytest src/tests/test_multi_scale_analysis.py

------
https://chatgpt.com/codex/tasks/task_e_68ceb22cf04c8333b3b9345ecea3ceaf